### PR TITLE
feat: export react context, return wallet session on wallet connect and break circular deps

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
 		"typecheck": "turbo run typecheck",
 		"size": "pnpm build && size-limit",
 		"prepare": "husky",
+		"check:circular-deps": "turbo run check:circular-deps",
 		"changeset": "changeset",
 		"version:packages": "changeset version",
 		"publish-packages": "changeset publish --filter @solana/client --filter @solana/react-hooks --filter @solana/web3-compat"

--- a/packages/client/package.json
+++ b/packages/client/package.json
@@ -49,9 +49,10 @@
 		"compile:typedefs": "tsc -p ./tsconfig.declarations.json",
 		"format": "biome check --write src",
 		"lint": "biome check src",
-		"test:typecheck": "tsc --noEmit",
+		"test:typecheck": "tsc --noEmit -p tsconfig.test.json",
 		"test": "vitest run --config ./vitest.config.ts",
-		"typecheck": "pnpm test:typecheck"
+		"typecheck": "tsc --noEmit",
+		"check:circular-deps": "madge --circular $(find ./src -name '*.ts' -o -name '*.tsx')"
 	},
 	"author": "Solana Maintainers <maintainers@solana.foundation>",
 	"repository": {

--- a/packages/client/src/actions.typecheck.ts
+++ b/packages/client/src/actions.typecheck.ts
@@ -36,6 +36,7 @@ import type {
 	SetClusterReturnType,
 	SolanaClient,
 } from './types';
+import type { WalletSession } from './wallet/types';
 
 type Equal<A, B> = (<T>() => T extends A ? 1 : 2) extends <T>() => T extends B ? 1 : 2 ? true : false;
 type Expect<T extends true> = T;
@@ -49,7 +50,7 @@ export type ConnectWalletParametersMatch = Expect<
 		}>
 	>
 >;
-export type ConnectWalletReturnMatch = Expect<Equal<ConnectWalletReturnType, Promise<void>>>;
+export type ConnectWalletReturnMatch = Expect<Equal<ConnectWalletReturnType, Promise<WalletSession>>>;
 export type DisconnectWalletParametersMatch = Expect<Equal<DisconnectWalletParameters, undefined>>;
 export type DisconnectWalletReturnMatch = Expect<Equal<DisconnectWalletReturnType, Promise<void>>>;
 

--- a/packages/client/src/client/actions.test.ts
+++ b/packages/client/src/client/actions.test.ts
@@ -2,7 +2,9 @@ import type { Address, Lamports, SendableTransaction, Signature, Transaction } f
 import type { TransactionWithLastValidBlockHeight } from '@solana/transaction-confirmation';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
-import type { ClientActions, SolanaClientRuntime, WalletConnector, WalletRegistry } from '../types';
+import type { SolanaClientRuntime } from '../rpc/types';
+import type { ClientActions } from '../types';
+import type { WalletConnector, WalletRegistry } from '../wallet/types';
 import { createActions } from './actions';
 import { createDefaultClientStore } from './createClientStore';
 

--- a/packages/client/src/client/actions.ts
+++ b/packages/client/src/client/actions.ts
@@ -19,16 +19,10 @@ import { fetchNonce } from '@solana-program/system';
 
 import { createLogger, formatError } from '../logging/logger';
 import { createSolanaRpcClient } from '../rpc/createSolanaRpcClient';
-import type {
-	AddressLookupTableData,
-	ClientActions,
-	ClientState,
-	ClientStore,
-	NonceAccountData,
-	SolanaClientRuntime,
-	WalletRegistry,
-} from '../types';
+import type { SolanaClientRuntime } from '../rpc/types';
+import type { AddressLookupTableData, ClientActions, ClientState, ClientStore, NonceAccountData } from '../types';
 import { now } from '../utils';
+import type { WalletRegistry, WalletSession } from '../wallet/types';
 
 type MutableRuntime = SolanaClientRuntime;
 
@@ -162,12 +156,12 @@ export function createActions({ connectors, logger: inputLogger, runtime, store 
 	 * Initiates a wallet connection using a registered connector.
 	 *
 	 * @param connectorId - Identifier for the desired wallet connector.
-	 * @returns Promise that resolves once the connection attempt has completed.
+	 * @returns Promise that resolves to the wallet session once the connection attempt has completed.
 	 */
 	async function connectWallet(
 		connectorId: string,
 		options: Readonly<{ autoConnect?: boolean }> = {},
-	): Promise<void> {
+	): Promise<WalletSession> {
 		walletEventsCleanup?.();
 		walletEventsCleanup = undefined;
 		const connector = connectors.get(connectorId);
@@ -206,6 +200,7 @@ export function createActions({ connectors, logger: inputLogger, runtime, store 
 				level: 'info',
 				message: 'wallet connected',
 			});
+			return session;
 		} catch (error) {
 			store.setState((state) => ({
 				...state,

--- a/packages/client/src/client/createClient.ts
+++ b/packages/client/src/client/createClient.ts
@@ -1,7 +1,8 @@
 import { createLogger, formatError } from '../logging/logger';
 import { createSolanaRpcClient } from '../rpc/createSolanaRpcClient';
+import type { SolanaClientRuntime } from '../rpc/types';
 import { applySerializableState } from '../serialization/state';
-import type { ClientStore, SolanaClient, SolanaClientConfig, SolanaClientRuntime } from '../types';
+import type { ClientStore, SolanaClient, SolanaClientConfig } from '../types';
 import { now } from '../utils';
 import { resolveCluster } from '../utils/cluster';
 import { createWalletRegistry } from '../wallet/registry';

--- a/packages/client/src/client/createClientHelpers.ts
+++ b/packages/client/src/client/createClientHelpers.ts
@@ -4,12 +4,13 @@ import { createSolTransferHelper, type SolTransferHelper } from '../features/sol
 import { createSplTokenHelper, type SplTokenHelper, type SplTokenHelperConfig } from '../features/spl';
 import { createStakeHelper, type StakeHelper } from '../features/stake';
 import { createTransactionHelper, type TransactionHelper } from '../features/transactions';
+import type { SolanaClientRuntime } from '../rpc/types';
 import {
 	type PrepareTransactionMessage,
 	type PrepareTransactionOptions,
 	prepareTransaction as prepareTransactionUtility,
 } from '../transactions/prepareTransaction';
-import type { ClientHelpers, ClientStore, SolanaClientRuntime } from '../types';
+import type { ClientHelpers, ClientStore } from '../types';
 
 type SplTokenCacheEntry = Readonly<{
 	baseCommitment?: Commitment;

--- a/packages/client/src/client/defaultClient.ts
+++ b/packages/client/src/client/defaultClient.ts
@@ -1,8 +1,9 @@
 import type { ClusterUrl, Commitment } from '@solana/kit';
 
-import type { SolanaClient, SolanaClientConfig, WalletConnector } from '../types';
+import type { SolanaClient, SolanaClientConfig } from '../types';
 import { type ClusterMoniker, resolveCluster } from '../utils/cluster';
 import { autoDiscover, backpack, phantom, solflare } from '../wallet/connectors';
+import type { WalletConnector } from '../wallet/types';
 import { createClient } from './createClient';
 
 type BasePassthrough = Omit<SolanaClientConfig, 'endpoint' | 'websocketEndpoint' | 'walletConnectors'>;

--- a/packages/client/src/client/watchers.test.ts
+++ b/packages/client/src/client/watchers.test.ts
@@ -1,7 +1,8 @@
 import type { Address, Signature } from '@solana/kit';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
-import type { ClientStore, SolanaClientRuntime } from '../types';
+import type { SolanaClientRuntime } from '../rpc/types';
+import type { ClientStore } from '../types';
 import { createDefaultClientStore } from './createClientStore';
 import { createWatchers } from './watchers';
 

--- a/packages/client/src/client/watchers.ts
+++ b/packages/client/src/client/watchers.ts
@@ -1,6 +1,7 @@
 import type { Lamports, SolanaRpcSubscriptionsApi } from '@solana/kit';
 
 import { createLogger, formatError } from '../logging/logger';
+import type { SolanaClientRuntime } from '../rpc/types';
 import type {
 	AccountCacheEntry,
 	AccountWatcherConfig,
@@ -8,7 +9,6 @@ import type {
 	ClientStore,
 	ClientWatchers,
 	SignatureWatcherConfig,
-	SolanaClientRuntime,
 	SubscriptionStatus,
 } from '../types';
 import { now } from '../utils';

--- a/packages/client/src/features/sol.test.ts
+++ b/packages/client/src/features/sol.test.ts
@@ -1,6 +1,6 @@
 import type { TransactionSigner } from '@solana/kit';
 import { beforeAll, beforeEach, describe, expect, it, vi } from 'vitest';
-import type { WalletSession } from '../types';
+import type { WalletSession } from '../wallet/types';
 
 type MutableMessage = {
 	instructions: unknown[];

--- a/packages/client/src/features/sol.ts
+++ b/packages/client/src/features/sol.ts
@@ -24,8 +24,9 @@ import {
 import { getTransferSolInstruction } from '@solana-program/system';
 
 import { lamportsMath } from '../numeric/lamports';
+import type { SolanaClientRuntime } from '../rpc/types';
 import { createWalletTransactionSigner, isWalletSession, resolveSignerMode } from '../signers/walletTransactionSigner';
-import type { SolanaClientRuntime, WalletSession } from '../types';
+import type { WalletSession } from '../wallet/types';
 
 type BlockhashLifetime = Readonly<{
 	blockhash: Blockhash;

--- a/packages/client/src/features/spl.ts
+++ b/packages/client/src/features/spl.ts
@@ -31,8 +31,9 @@ import {
 } from '@solana-program/token';
 
 import { createTokenAmount, type TokenAmountMath } from '../numeric/amounts';
+import type { SolanaClientRuntime } from '../rpc/types';
 import { createWalletTransactionSigner, isWalletSession, resolveSignerMode } from '../signers/walletTransactionSigner';
-import type { SolanaClientRuntime, WalletSession } from '../types';
+import type { WalletSession } from '../wallet/types';
 import type { SolTransferSendOptions } from './sol';
 
 type BlockhashLifetime = Readonly<{

--- a/packages/client/src/features/stake.ts
+++ b/packages/client/src/features/stake.ts
@@ -32,8 +32,9 @@ import {
 import { getCreateAccountInstruction } from '@solana-program/system';
 
 import { lamportsMath } from '../numeric/lamports';
+import type { SolanaClientRuntime } from '../rpc/types';
 import { createWalletTransactionSigner, isWalletSession, resolveSignerMode } from '../signers/walletTransactionSigner';
-import type { SolanaClientRuntime, WalletSession } from '../types';
+import type { WalletSession } from '../wallet/types';
 
 type BlockhashLifetime = Readonly<{
 	blockhash: Blockhash;

--- a/packages/client/src/features/transactions.ts
+++ b/packages/client/src/features/transactions.ts
@@ -37,14 +37,14 @@ import {
 	getSetComputeUnitLimitInstruction,
 	getSetComputeUnitPriceInstruction,
 } from '@solana-program/compute-budget';
-
+import type { SolanaClientRuntime } from '../rpc/types';
 import { createWalletTransactionSigner, isWalletSession, resolveSignerMode } from '../signers/walletTransactionSigner';
 import {
 	type PrepareTransactionMessage,
 	type PrepareTransactionOptions,
 	prepareTransaction as prepareTransactionUtility,
 } from '../transactions/prepareTransaction';
-import type { SolanaClientRuntime, WalletSession } from '../types';
+import type { WalletSession } from '../wallet/types';
 
 type BlockhashLifetime = Readonly<{
 	blockhash: Blockhash;

--- a/packages/client/src/index.ts
+++ b/packages/client/src/index.ts
@@ -101,6 +101,7 @@ export {
 	type SimulateTransactionOptions,
 	type SolanaRpcClient,
 } from './rpc/createSolanaRpcClient';
+export type { SolanaClientRuntime } from './rpc/types';
 export { bigintFromJson, bigintToJson, lamportsFromJson, lamportsToJson } from './serialization/json';
 export {
 	applySerializableState,
@@ -178,11 +179,6 @@ export type {
 	SetClusterReturnType,
 	SolanaClient,
 	SolanaClientConfig,
-	WalletConnector,
-	WalletConnectorMetadata,
-	WalletRegistry,
-	WalletSession,
-	WalletStatus,
 } from './types';
 export { type AddressLike, toAddress, toAddressString } from './utils/addressLike';
 export { type ClusterMoniker, resolveCluster } from './utils/cluster';
@@ -194,3 +190,10 @@ export {
 	getWalletStandardConnectors,
 	watchWalletStandardConnectors,
 } from './wallet/standard';
+export type {
+	WalletConnector,
+	WalletConnectorMetadata,
+	WalletRegistry,
+	WalletSession,
+	WalletStatus,
+} from './wallet/types';

--- a/packages/client/src/rpc/types.ts
+++ b/packages/client/src/rpc/types.ts
@@ -1,0 +1,7 @@
+type SolanaRpcInstance = ReturnType<typeof import('@solana/kit')['createSolanaRpc']>;
+type SolanaSubscriptionsInstance = ReturnType<typeof import('@solana/kit')['createSolanaRpcSubscriptions']>;
+
+export type SolanaClientRuntime = {
+	rpc: SolanaRpcInstance;
+	rpcSubscriptions: SolanaSubscriptionsInstance;
+};

--- a/packages/client/src/signers/walletTransactionSigner.test.ts
+++ b/packages/client/src/signers/walletTransactionSigner.test.ts
@@ -2,7 +2,7 @@ import { getBase58Decoder } from '@solana/codecs-strings';
 import type { TransactionSigner } from '@solana/kit';
 import { describe, expect, it, vi } from 'vitest';
 
-import type { WalletSession } from '../types';
+import type { WalletSession } from '../wallet/types';
 import { createWalletTransactionSigner, isWalletSession, resolveSignerMode } from './walletTransactionSigner';
 
 type SessionTransaction = Parameters<NonNullable<WalletSession['signTransaction']>>[0];

--- a/packages/client/src/signers/walletTransactionSigner.ts
+++ b/packages/client/src/signers/walletTransactionSigner.ts
@@ -15,8 +15,7 @@ import {
 	type TransactionWithinSizeLimit,
 	type TransactionWithLifetime,
 } from '@solana/kit';
-
-import type { WalletSession } from '../types';
+import type { WalletSession } from '../wallet/types';
 
 type WalletTransactionSignerMode = 'partial' | 'send';
 

--- a/packages/client/src/types.ts
+++ b/packages/client/src/types.ts
@@ -15,79 +15,14 @@ import type { SplTokenHelper, SplTokenHelperConfig } from './features/spl';
 import type { StakeHelper } from './features/stake';
 import type { TransactionHelper } from './features/transactions';
 import type { SolanaRpcClient } from './rpc/createSolanaRpcClient';
+import type { SolanaClientRuntime } from './rpc/types';
 import type { PrepareTransactionMessage, PrepareTransactionOptions } from './transactions/prepareTransaction';
 import type { ClusterMoniker } from './utils/cluster';
-
-type SolanaRpcInstance = ReturnType<typeof import('@solana/kit')['createSolanaRpc']>;
-type SolanaSubscriptionsInstance = ReturnType<typeof import('@solana/kit')['createSolanaRpcSubscriptions']>;
+import type { WalletConnector, WalletRegistry, WalletSession, WalletStatus } from './wallet/types';
 
 export type LogLevel = 'debug' | 'error' | 'info' | 'warn';
 
 export type ClientLogger = (event: { data?: Record<string, unknown>; level: LogLevel; message: string }) => void;
-
-export type WalletConnectorMetadata = Readonly<{
-	canAutoConnect?: boolean;
-	icon?: string;
-	id: string;
-	kind?: string;
-	name: string;
-	ready?: boolean;
-}>;
-
-export type WalletAccount = Readonly<{
-	address: Address;
-	label?: string;
-	publicKey: Uint8Array;
-}>;
-
-export type WalletSession = Readonly<{
-	account: WalletAccount;
-	connector: WalletConnectorMetadata;
-	disconnect(): Promise<void>;
-	onAccountsChanged?: (listener: (accounts: WalletAccount[]) => void) => () => void;
-	sendTransaction?(
-		transaction: SendableTransaction & Transaction,
-		config?: Readonly<{ commitment?: Commitment }>,
-	): Promise<Signature>;
-	signMessage?(message: Uint8Array): Promise<Uint8Array>;
-	signTransaction?(transaction: SendableTransaction & Transaction): Promise<SendableTransaction & Transaction>;
-}>;
-
-export type WalletConnector = WalletConnectorMetadata & {
-	connect(opts?: Readonly<{ autoConnect?: boolean; allowInteractiveFallback?: boolean }>): Promise<WalletSession>;
-	disconnect(): Promise<void>;
-	isSupported(): boolean;
-};
-
-type WalletStatusConnected = Readonly<{
-	autoConnect?: boolean;
-	connectorId: string;
-	session: WalletSession;
-	status: 'connected';
-}>;
-
-type WalletStatusConnecting = Readonly<{
-	autoConnect?: boolean;
-	connectorId: string;
-	status: 'connecting';
-}>;
-
-type WalletStatusDisconnected = Readonly<{
-	status: 'disconnected';
-}>;
-
-type WalletStatusError = Readonly<{
-	autoConnect?: boolean;
-	connectorId?: string;
-	error: unknown;
-	status: 'error';
-}>;
-
-export type WalletStatus =
-	| WalletStatusConnected
-	| WalletStatusConnecting
-	| WalletStatusDisconnected
-	| WalletStatusError;
 
 type ClusterStatusConnecting = Readonly<{ status: 'connecting' }>;
 
@@ -202,11 +137,6 @@ export type SerializableSolanaState = Readonly<{
 	websocketEndpoint?: ClusterUrl;
 }>;
 
-export type SolanaClientRuntime = {
-	rpc: SolanaRpcInstance;
-	rpcSubscriptions: SolanaSubscriptionsInstance;
-};
-
 export type BalanceWatcherConfig = Readonly<{
 	address: Address;
 	commitment?: Commitment;
@@ -232,7 +162,7 @@ export type ConnectWalletParameters = Readonly<{
 	options?: Readonly<{ autoConnect?: boolean; allowInteractiveFallback?: boolean }>;
 }>;
 
-export type ConnectWalletReturnType = Promise<void>;
+export type ConnectWalletReturnType = Promise<WalletSession>;
 
 export type DisconnectWalletParameters = undefined;
 
@@ -348,11 +278,6 @@ export type ClientHelpers = Readonly<{
 	prepareTransaction<TMessage extends PrepareTransactionMessage>(
 		config: PrepareTransactionOptions<TMessage>,
 	): Promise<TMessage & TransactionMessageWithBlockhashLifetime>;
-}>;
-
-export type WalletRegistry = Readonly<{
-	all: readonly WalletConnector[];
-	get(id: string): WalletConnector | undefined;
 }>;
 
 export type SolanaClient = Readonly<{

--- a/packages/client/src/wallet/connectors.ts
+++ b/packages/client/src/wallet/connectors.ts
@@ -1,8 +1,8 @@
 import { getWallets } from '@wallet-standard/app';
 import type { Wallet } from '@wallet-standard/base';
 import { StandardConnect } from '@wallet-standard/features';
-import type { WalletConnector } from '../types';
 import { createWalletStandardConnector } from './standard';
+import type { WalletConnector } from './types';
 
 type DiscoveryOptions = Readonly<{
 	overrides?: (wallet: Wallet) => Parameters<typeof createWalletStandardConnector>[1];

--- a/packages/client/src/wallet/registry.test.ts
+++ b/packages/client/src/wallet/registry.test.ts
@@ -1,7 +1,6 @@
 import { describe, expect, it } from 'vitest';
-
-import type { WalletConnector } from '../types';
 import { createWalletRegistry } from './registry';
+import type { WalletConnector } from './types';
 
 describe('wallet registry', () => {
 	const connector = (id: string): WalletConnector => ({

--- a/packages/client/src/wallet/registry.ts
+++ b/packages/client/src/wallet/registry.ts
@@ -1,4 +1,4 @@
-import type { WalletConnector, WalletRegistry } from '../types';
+import type { WalletConnector, WalletRegistry } from './types';
 
 /**
  * Creates an in-memory wallet registry from the provided connectors.

--- a/packages/client/src/wallet/standard.ts
+++ b/packages/client/src/wallet/standard.ts
@@ -21,7 +21,7 @@ import type {
 } from '@wallet-standard/features';
 import { StandardConnect, StandardDisconnect, StandardEvents } from '@wallet-standard/features';
 
-import type { WalletAccount, WalletConnector, WalletConnectorMetadata, WalletSession } from '../types';
+import type { WalletAccount, WalletConnector, WalletConnectorMetadata, WalletSession } from './types';
 
 export type WalletStandardConnectorMetadata = Readonly<{
 	canAutoConnect?: boolean;

--- a/packages/client/src/wallet/types.ts
+++ b/packages/client/src/wallet/types.ts
@@ -1,0 +1,70 @@
+import type { Address, Commitment, SendableTransaction, Signature, Transaction } from '@solana/kit';
+
+export type WalletConnectorMetadata = Readonly<{
+	canAutoConnect?: boolean;
+	icon?: string;
+	id: string;
+	kind?: string;
+	name: string;
+	ready?: boolean;
+}>;
+
+export type WalletAccount = Readonly<{
+	address: Address;
+	label?: string;
+	publicKey: Uint8Array;
+}>;
+
+export type WalletSession = Readonly<{
+	account: WalletAccount;
+	connector: WalletConnectorMetadata;
+	disconnect(): Promise<void>;
+	onAccountsChanged?: (listener: (accounts: WalletAccount[]) => void) => () => void;
+	sendTransaction?(
+		transaction: SendableTransaction & Transaction,
+		config?: Readonly<{ commitment?: Commitment }>,
+	): Promise<Signature>;
+	signMessage?(message: Uint8Array): Promise<Uint8Array>;
+	signTransaction?(transaction: SendableTransaction & Transaction): Promise<SendableTransaction & Transaction>;
+}>;
+
+export type WalletConnector = WalletConnectorMetadata & {
+	connect(opts?: Readonly<{ autoConnect?: boolean; allowInteractiveFallback?: boolean }>): Promise<WalletSession>;
+	disconnect(): Promise<void>;
+	isSupported(): boolean;
+};
+
+type WalletStatusConnected = Readonly<{
+	autoConnect?: boolean;
+	connectorId: string;
+	session: WalletSession;
+	status: 'connected';
+}>;
+
+type WalletStatusConnecting = Readonly<{
+	autoConnect?: boolean;
+	connectorId: string;
+	status: 'connecting';
+}>;
+
+type WalletStatusDisconnected = Readonly<{
+	status: 'disconnected';
+}>;
+
+type WalletStatusError = Readonly<{
+	autoConnect?: boolean;
+	connectorId?: string;
+	error: unknown;
+	status: 'error';
+}>;
+
+export type WalletStatus =
+	| WalletStatusConnected
+	| WalletStatusConnecting
+	| WalletStatusDisconnected
+	| WalletStatusError;
+
+export type WalletRegistry = Readonly<{
+	all: readonly WalletConnector[];
+	get(id: string): WalletConnector | undefined;
+}>;

--- a/packages/client/tsconfig.test.json
+++ b/packages/client/tsconfig.test.json
@@ -1,0 +1,8 @@
+{
+	"extends": "./tsconfig.json",
+	"compilerOptions": {
+		"module": "ESNext"
+	},
+	"include": ["src/**/*.test.ts", "src/**/*.test.tsx"],
+	"exclude": []
+}

--- a/packages/react-hooks/package.json
+++ b/packages/react-hooks/package.json
@@ -34,7 +34,8 @@
 		"lint": "biome check src",
 		"test:typecheck": "tsc --noEmit",
 		"test": "vitest run --config ../../vitest.config.ts",
-		"typecheck": "pnpm test:typecheck"
+		"typecheck": "pnpm test:typecheck",
+		"check:circular-deps": "madge --circular $(find ./src -name '*.ts' -o -name '*.tsx')"
 	},
 	"author": "Solana Maintainers <maintainers@solana.foundation>",
 	"repository": {

--- a/packages/react-hooks/src/context.tsx
+++ b/packages/react-hooks/src/context.tsx
@@ -8,7 +8,7 @@ import {
 import type { ReactNode } from 'react';
 import { createContext, useContext, useEffect, useMemo } from 'react';
 
-const SolanaClientContext = createContext<SolanaClient | null>(null);
+export const SolanaClientContext = createContext<SolanaClient | null>(null);
 
 type ProviderProps = Readonly<{
 	children: ReactNode;

--- a/packages/react-hooks/src/hooks.ts
+++ b/packages/react-hooks/src/hooks.ts
@@ -237,7 +237,7 @@ export function useWalletActions() {
 export function useConnectWallet(): (
 	connectorId: string,
 	options?: Readonly<{ autoConnect?: boolean; allowInteractiveFallback?: boolean }>,
-) => Promise<void> {
+) => Promise<WalletSession> {
 	const client = useSolanaClient();
 	return useCallback(
 		(connectorId: string, options?: Readonly<{ autoConnect?: boolean; allowInteractiveFallback?: boolean }>) =>

--- a/packages/react-hooks/src/index.ts
+++ b/packages/react-hooks/src/index.ts
@@ -6,7 +6,7 @@ export type {
 	UseSolanaClientParameters,
 	UseSolanaClientReturnType,
 } from './context';
-export { SolanaClientProvider, useSolanaClient } from './context';
+export { SolanaClientContext, SolanaClientProvider, useSolanaClient } from './context';
 export type {
 	SignatureWaitStatus,
 	UseAccountParameters,

--- a/packages/react-hooks/src/ui.tsx
+++ b/packages/react-hooks/src/ui.tsx
@@ -9,7 +9,7 @@ type WalletConnectionState = Readonly<{
 	connect(
 		connectorId: string,
 		options?: Readonly<{ autoConnect?: boolean; allowInteractiveFallback?: boolean }>,
-	): Promise<void>;
+	): Promise<WalletSession>;
 	connected: boolean;
 	connecting: boolean;
 	connectors: readonly WalletConnector[];
@@ -154,11 +154,12 @@ export function useWalletModalState(options: WalletModalStateOptions = {}): Wall
 
 	const connect = useCallback(
 		async (connectorId: string, connectOptions?: Readonly<{ autoConnect?: boolean }>) => {
-			await connection.connect(connectorId, connectOptions);
+			const session = await connection.connect(connectorId, connectOptions);
 			setSelectedConnector(connectorId);
 			if (closeOnConnect) {
 				setIsOpen(false);
 			}
+			return session;
 		},
 		[closeOnConnect, connection],
 	);

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -166,7 +166,7 @@ importers:
         version: link:../../packages/react-hooks
       next:
         specifier: ^16.0.9
-        version: 16.0.10(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+        version: 16.1.1(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
       react:
         specifier: ^19.0.0
         version: 19.2.0
@@ -1101,53 +1101,53 @@ packages:
   '@manypkg/get-packages@1.1.3':
     resolution: {integrity: sha512-fo+QhuU3qE/2TQMQmbVMqaQ6EWbMhi4ABWP+O4AM1NqPBuy0OrApV5LO6BrrgnhtAHS2NH6RrVk9OL181tTi8A==}
 
-  '@next/env@16.0.10':
-    resolution: {integrity: sha512-8tuaQkyDVgeONQ1MeT9Mkk8pQmZapMKFh5B+OrFUlG3rVmYTXcXlBetBgTurKXGaIZvkoqRT9JL5K3phXcgang==}
+  '@next/env@16.1.1':
+    resolution: {integrity: sha512-3oxyM97Sr2PqiVyMyrZUtrtM3jqqFxOQJVuKclDsgj/L728iZt/GyslkN4NwarledZATCenbk4Offjk1hQmaAA==}
 
-  '@next/swc-darwin-arm64@16.0.10':
-    resolution: {integrity: sha512-4XgdKtdVsaflErz+B5XeG0T5PeXKDdruDf3CRpnhN+8UebNa5N2H58+3GDgpn/9GBurrQ1uWW768FfscwYkJRg==}
+  '@next/swc-darwin-arm64@16.1.1':
+    resolution: {integrity: sha512-JS3m42ifsVSJjSTzh27nW+Igfha3NdBOFScr9C80hHGrWx55pTrVL23RJbqir7k7/15SKlrLHhh/MQzqBBYrQA==}
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [darwin]
 
-  '@next/swc-darwin-x64@16.0.10':
-    resolution: {integrity: sha512-spbEObMvRKkQ3CkYVOME+ocPDFo5UqHb8EMTS78/0mQ+O1nqE8toHJVioZo4TvebATxgA8XMTHHrScPrn68OGw==}
+  '@next/swc-darwin-x64@16.1.1':
+    resolution: {integrity: sha512-hbyKtrDGUkgkyQi1m1IyD3q4I/3m9ngr+V93z4oKHrPcmxwNL5iMWORvLSGAf2YujL+6HxgVvZuCYZfLfb4bGw==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [darwin]
 
-  '@next/swc-linux-arm64-gnu@16.0.10':
-    resolution: {integrity: sha512-uQtWE3X0iGB8apTIskOMi2w/MKONrPOUCi5yLO+v3O8Mb5c7K4Q5KD1jvTpTF5gJKa3VH/ijKjKUq9O9UhwOYw==}
+  '@next/swc-linux-arm64-gnu@16.1.1':
+    resolution: {integrity: sha512-/fvHet+EYckFvRLQ0jPHJCUI5/B56+2DpI1xDSvi80r/3Ez+Eaa2Yq4tJcRTaB1kqj/HrYKn8Yplm9bNoMJpwQ==}
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [linux]
 
-  '@next/swc-linux-arm64-musl@16.0.10':
-    resolution: {integrity: sha512-llA+hiDTrYvyWI21Z0L1GiXwjQaanPVQQwru5peOgtooeJ8qx3tlqRV2P7uH2pKQaUfHxI/WVarvI5oYgGxaTw==}
+  '@next/swc-linux-arm64-musl@16.1.1':
+    resolution: {integrity: sha512-MFHrgL4TXNQbBPzkKKur4Fb5ICEJa87HM7fczFs2+HWblM7mMLdco3dvyTI+QmLBU9xgns/EeeINSZD6Ar+oLg==}
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [linux]
 
-  '@next/swc-linux-x64-gnu@16.0.10':
-    resolution: {integrity: sha512-AK2q5H0+a9nsXbeZ3FZdMtbtu9jxW4R/NgzZ6+lrTm3d6Zb7jYrWcgjcpM1k8uuqlSy4xIyPR2YiuUr+wXsavA==}
+  '@next/swc-linux-x64-gnu@16.1.1':
+    resolution: {integrity: sha512-20bYDfgOQAPUkkKBnyP9PTuHiJGM7HzNBbuqmD0jiFVZ0aOldz+VnJhbxzjcSabYsnNjMPsE0cyzEudpYxsrUQ==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [linux]
 
-  '@next/swc-linux-x64-musl@16.0.10':
-    resolution: {integrity: sha512-1TDG9PDKivNw5550S111gsO4RGennLVl9cipPhtkXIFVwo31YZ73nEbLjNC8qG3SgTz/QZyYyaFYMeY4BKZR/g==}
+  '@next/swc-linux-x64-musl@16.1.1':
+    resolution: {integrity: sha512-9pRbK3M4asAHQRkwaXwu601oPZHghuSC8IXNENgbBSyImHv/zY4K5udBusgdHkvJ/Tcr96jJwQYOll0qU8+fPA==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [linux]
 
-  '@next/swc-win32-arm64-msvc@16.0.10':
-    resolution: {integrity: sha512-aEZIS4Hh32xdJQbHz121pyuVZniSNoqDVx1yIr2hy+ZwJGipeqnMZBJHyMxv2tiuAXGx6/xpTcQJ6btIiBjgmg==}
+  '@next/swc-win32-arm64-msvc@16.1.1':
+    resolution: {integrity: sha512-bdfQkggaLgnmYrFkSQfsHfOhk/mCYmjnrbRCGgkMcoOBZ4n+TRRSLmT/CU5SATzlBJ9TpioUyBW/vWFXTqQRiA==}
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [win32]
 
-  '@next/swc-win32-x64-msvc@16.0.10':
-    resolution: {integrity: sha512-E+njfCoFLb01RAFEnGZn6ERoOqhK1Gl3Lfz1Kjnj0Ulfu7oJbuMyvBKNj/bw8XZnenHDASlygTjZICQW+rYW1Q==}
+  '@next/swc-win32-x64-msvc@16.1.1':
+    resolution: {integrity: sha512-Ncwbw2WJ57Al5OX0k4chM68DKhEPlrXBaSXDCi2kPi5f4d8b3ejr3RRJGfKBLrn2YJL5ezNS7w2TZLHSti8CMw==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [win32]
@@ -2685,8 +2685,8 @@ packages:
   nanospinner@1.2.2:
     resolution: {integrity: sha512-Zt/AmG6qRU3e+WnzGGLuMCEAO/dAu45stNbHY223tUxldaDAeE+FxSPsd9Q+j+paejmm0ZbrNVs5Sraqy3dRxA==}
 
-  next@16.0.10:
-    resolution: {integrity: sha512-RtWh5PUgI+vxlV3HdR+IfWA1UUHu0+Ram/JBO4vWB54cVPentCD0e+lxyAYEsDTqGGMg7qpjhKh6dc6aW7W/sA==}
+  next@16.1.1:
+    resolution: {integrity: sha512-QI+T7xrxt1pF6SQ/JYFz95ro/mg/1Znk5vBebsWwbpejj1T0A23hO7GYEaVac9QUOT2BIMiuzm0L99ooq7k0/w==}
     engines: {node: '>=20.9.0'}
     hasBin: true
     peerDependencies:
@@ -3984,30 +3984,30 @@ snapshots:
       globby: 11.1.0
       read-yaml-file: 1.1.0
 
-  '@next/env@16.0.10': {}
+  '@next/env@16.1.1': {}
 
-  '@next/swc-darwin-arm64@16.0.10':
+  '@next/swc-darwin-arm64@16.1.1':
     optional: true
 
-  '@next/swc-darwin-x64@16.0.10':
+  '@next/swc-darwin-x64@16.1.1':
     optional: true
 
-  '@next/swc-linux-arm64-gnu@16.0.10':
+  '@next/swc-linux-arm64-gnu@16.1.1':
     optional: true
 
-  '@next/swc-linux-arm64-musl@16.0.10':
+  '@next/swc-linux-arm64-musl@16.1.1':
     optional: true
 
-  '@next/swc-linux-x64-gnu@16.0.10':
+  '@next/swc-linux-x64-gnu@16.1.1':
     optional: true
 
-  '@next/swc-linux-x64-musl@16.0.10':
+  '@next/swc-linux-x64-musl@16.1.1':
     optional: true
 
-  '@next/swc-win32-arm64-msvc@16.0.10':
+  '@next/swc-win32-arm64-msvc@16.1.1':
     optional: true
 
-  '@next/swc-win32-x64-msvc@16.0.10':
+  '@next/swc-win32-x64-msvc@16.1.1':
     optional: true
 
   '@noble/curves@1.9.7':
@@ -5616,24 +5616,25 @@ snapshots:
     dependencies:
       picocolors: 1.1.1
 
-  next@16.0.10(react-dom@19.2.0(react@19.2.0))(react@19.2.0):
+  next@16.1.1(react-dom@19.2.0(react@19.2.0))(react@19.2.0):
     dependencies:
-      '@next/env': 16.0.10
+      '@next/env': 16.1.1
       '@swc/helpers': 0.5.15
+      baseline-browser-mapping: 2.8.25
       caniuse-lite: 1.0.30001759
       postcss: 8.4.31
       react: 19.2.0
       react-dom: 19.2.0(react@19.2.0)
       styled-jsx: 5.1.6(react@19.2.0)
     optionalDependencies:
-      '@next/swc-darwin-arm64': 16.0.10
-      '@next/swc-darwin-x64': 16.0.10
-      '@next/swc-linux-arm64-gnu': 16.0.10
-      '@next/swc-linux-arm64-musl': 16.0.10
-      '@next/swc-linux-x64-gnu': 16.0.10
-      '@next/swc-linux-x64-musl': 16.0.10
-      '@next/swc-win32-arm64-msvc': 16.0.10
-      '@next/swc-win32-x64-msvc': 16.0.10
+      '@next/swc-darwin-arm64': 16.1.1
+      '@next/swc-darwin-x64': 16.1.1
+      '@next/swc-linux-arm64-gnu': 16.1.1
+      '@next/swc-linux-arm64-musl': 16.1.1
+      '@next/swc-linux-x64-gnu': 16.1.1
+      '@next/swc-linux-x64-musl': 16.1.1
+      '@next/swc-win32-arm64-msvc': 16.1.1
+      '@next/swc-win32-x64-msvc': 16.1.1
       sharp: 0.34.5
     transitivePeerDependencies:
       - '@babel/core'

--- a/turbo.json
+++ b/turbo.json
@@ -22,6 +22,9 @@
 		"typecheck": {
 			"dependsOn": ["^build"],
 			"outputs": []
+		},
+		"check:circular-deps": {
+			"outputs": []
 		}
 	}
 }


### PR DESCRIPTION
## What does this PR do?

This PR does a couple of things:

1. Exports `SolanaClientContext` for external use cases
2. Returns the `WalletSession` object after a connector connects.
3. Breaks the circular dependeciess in the repo

## Why was it implemented this way?

### Exporting `SolanaClientContext`
We needed this in a widget use case. The widget has it's internal wallet management. However, we want our partners to be able bring their own wallet management solution and the widget to use the external wallet management when available. 
We do this by checking if there is an existing `SolanaClientContext` in the tree, and reusing it if there is, else, we create a new context.


### Returning the `WalletSession` after connection
Although there is a `useSession` hook to fetch when the session. In our use case, we have a synchronous flow where onConnect, we show the user he a connecting modal and after connection, our internal state is updated, and the we close the modal. Doing this with the hook would work but would not be a linear flow.

### Break circular dependencies in the repo.
After making the above updates, I discovered there were circular dependencies in the repo.
1. I broke out the `src/types.ts` files into smaller `types.ts` files for each module / folder.
2. I added [`madge`](https://www.npmjs.com/package/madge) to the devDependencies to help check for circular dependencies. 