### PR TITLE
fix: mark hooks as client components

### DIFF
--- a/.changeset/shiny-lions-sing.md
+++ b/.changeset/shiny-lions-sing.md
@@ -1,0 +1,5 @@
+---
+"@solana/react-hooks": minor
+---
+
+Mark the package entry point and context providers as Client Components so Next.js always loads the client runtime.

--- a/packages/react-hooks/src/QueryProvider.tsx
+++ b/packages/react-hooks/src/QueryProvider.tsx
@@ -1,3 +1,5 @@
+'use client';
+
 import type { JSX, ReactNode } from 'react';
 import { useMemo, useRef } from 'react';
 import { type Cache, SWRConfig, type SWRConfiguration } from 'swr';

--- a/packages/react-hooks/src/SolanaProvider.tsx
+++ b/packages/react-hooks/src/SolanaProvider.tsx
@@ -1,3 +1,5 @@
+'use client';
+
 import type { SolanaClient, SolanaClientConfig } from '@solana/client';
 import type { ReactNode } from 'react';
 import { useEffect, useRef, useState } from 'react';

--- a/packages/react-hooks/src/index.ts
+++ b/packages/react-hooks/src/index.ts
@@ -1,3 +1,5 @@
+'use client';
+
 export { SolanaClientProvider, useSolanaClient } from './context';
 export {
 	useAccount,


### PR DESCRIPTION
## Summary
- force the exported provider modules to be Client Components so Next loads the client SWR entry
- add a minor changeset for @solana/react-hooks

Fixes #7

## Testing
- pnpm lint
- pnpm --filter @solana/react-hooks test
