### PR TITLE
fix: stop logging cluster ready info

### DIFF
--- a/.changeset/quiet-timers-flow.md
+++ b/.changeset/quiet-timers-flow.md
@@ -1,0 +1,5 @@
+---
+"@solana/client": patch
+---
+
+Stop logging cluster connection details when the client marks a cluster as ready.

--- a/packages/client/src/client/actions.ts
+++ b/packages/client/src/client/actions.ts
@@ -127,11 +127,6 @@ export function createActions({ connectors, logger: inputLogger, runtime, store 
 				},
 				lastUpdatedAt: now(),
 			}));
-			logger({
-				data: { endpoint, latencyMs, websocketEndpoint },
-				level: 'info',
-				message: 'cluster ready',
-			});
 		} catch (error) {
 			store.setState((state) => ({
 				...state,


### PR DESCRIPTION
## Summary
- remove the info log emitted whenever the client marks a cluster as ready
- add a patch changeset for @solana/client

## Testing
- pnpm --filter @solana/client lint
