### PR TITLE
Add serializable state helpers and connector ready flag

### DIFF
--- a/packages/client/src/index.ts
+++ b/packages/client/src/index.ts
@@ -65,6 +65,7 @@ export {
 	type SolanaRpcClient,
 } from './rpc/createSolanaRpcClient';
 export { bigintFromJson, bigintToJson, lamportsFromJson, lamportsToJson } from './serialization/json';
+export { applySerializableState, getInitialSerializableState } from './serialization/state';
 export {
 	type ConfirmationCommitment,
 	confirmationMeetsCommitment,
@@ -107,6 +108,7 @@ export type {
 	ClientState,
 	ClientStore,
 	ClientWatchers,
+	SerializableSolanaState,
 	SolanaClient,
 	SolanaClientConfig,
 	WalletConnector,

--- a/packages/client/src/serialization/state.test.ts
+++ b/packages/client/src/serialization/state.test.ts
@@ -1,0 +1,53 @@
+import { describe, expect, it } from 'vitest';
+
+import type { SolanaClientConfig } from '../types';
+import { applySerializableState, getInitialSerializableState } from './state';
+
+const baseConfig: SolanaClientConfig = {
+	endpoint: 'https://api.devnet.solana.com',
+};
+
+describe('serialization state helpers', () => {
+	it('derives an initial serializable state from config', () => {
+		const state = getInitialSerializableState({
+			...baseConfig,
+			commitment: 'finalized',
+			websocketEndpoint: 'wss://api.devnet.solana.com',
+		});
+
+		expect(state).toMatchObject({
+			autoconnect: false,
+			commitment: 'finalized',
+			endpoint: baseConfig.endpoint,
+			lastConnectorId: null,
+			lastPublicKey: null,
+			version: 1,
+			websocketEndpoint: 'wss://api.devnet.solana.com',
+		});
+	});
+
+	it('returns the original config when no state is provided', () => {
+		const merged = applySerializableState(baseConfig, null);
+		expect(merged).toEqual(baseConfig);
+	});
+
+	it('merges persisted state over config when provided', () => {
+		const merged = applySerializableState(
+			{ ...baseConfig, commitment: 'processed', websocketEndpoint: 'wss://example.com' },
+			{
+				autoconnect: true,
+				commitment: 'confirmed',
+				endpoint: 'https://api.mainnet-beta.solana.com',
+				lastConnectorId: 'phantom',
+				lastPublicKey: 'pubkey',
+				version: 1,
+			},
+		);
+
+		expect(merged).toMatchObject({
+			endpoint: 'https://api.mainnet-beta.solana.com',
+			commitment: 'confirmed',
+			websocketEndpoint: 'wss://example.com',
+		});
+	});
+});

--- a/packages/client/src/serialization/state.ts
+++ b/packages/client/src/serialization/state.ts
@@ -1,0 +1,39 @@
+import type { SerializableSolanaState, SolanaClientConfig } from '../types';
+
+const SERIALIZABLE_STATE_VERSION = 1;
+
+/**
+ * Derive the minimal serializable state for a client based on its config.
+ */
+export function getInitialSerializableState(config: SolanaClientConfig): SerializableSolanaState {
+	return {
+		autoconnect: false,
+		commitment: config.commitment,
+		endpoint: config.endpoint,
+		lastConnectorId: null,
+		lastPublicKey: null,
+		version: SERIALIZABLE_STATE_VERSION,
+		websocketEndpoint: config.websocketEndpoint,
+	};
+}
+
+/**
+ * Applies persisted serializable state on top of a base client config.
+ *
+ * This is a pure helper; it does not mutate the client. Callers can use the returned
+ * config object to construct a hydrated client instance.
+ */
+export function applySerializableState(
+	config: SolanaClientConfig,
+	state: SerializableSolanaState | null | undefined,
+): SolanaClientConfig {
+	if (!state) {
+		return config;
+	}
+	return {
+		...config,
+		commitment: state.commitment ?? config.commitment,
+		endpoint: state.endpoint ?? config.endpoint,
+		websocketEndpoint: state.websocketEndpoint ?? config.websocketEndpoint,
+	};
+}

--- a/packages/client/src/types.ts
+++ b/packages/client/src/types.ts
@@ -28,6 +28,7 @@ export type WalletConnectorMetadata = Readonly<{
 	icon?: string;
 	id: string;
 	name: string;
+	ready?: boolean;
 }>;
 
 export type WalletAccount = Readonly<{
@@ -164,6 +165,16 @@ export type SolanaClientConfig = Readonly<{
 	logger?: ClientLogger;
 	rpcClient?: SolanaRpcClient;
 	walletConnectors?: readonly WalletConnector[];
+	websocketEndpoint?: ClusterUrl;
+}>;
+
+export type SerializableSolanaState = Readonly<{
+	autoconnect?: boolean;
+	commitment?: Commitment;
+	endpoint: ClusterUrl;
+	lastConnectorId?: string | null;
+	lastPublicKey?: string | null;
+	version: number;
 	websocketEndpoint?: ClusterUrl;
 }>;
 

--- a/packages/client/src/wallet/standard.ts
+++ b/packages/client/src/wallet/standard.ts
@@ -126,6 +126,7 @@ export function createWalletStandardConnector(
 		icon: options.icon ?? wallet.icon,
 		id: options.id ?? deriveConnectorId(wallet),
 		name: options.name ?? wallet.name,
+		ready: typeof window !== 'undefined',
 	};
 
 	/**


### PR DESCRIPTION
## Summary
- add SerializableSolanaState type and export getInitialSerializableState/applySerializableState helpers
- add connector metadata tweaks: optional ready flag, stable Wallet Standard ids/kind with dedup, and tests

Resolves #19.