### PR TITLE
Harden Wallet Standard connector metadata

### DIFF
--- a/.changeset/connector-kind-ready.md
+++ b/.changeset/connector-kind-ready.md
@@ -1,0 +1,5 @@
+---
+"@solana/client": patch
+---
+
+Harden Wallet Standard connectors: add a `kind` field, stable `wallet-standard:<name>` ids, optional `ready` metadata, and tests for metadata/deduplication.

--- a/packages/client/src/types.ts
+++ b/packages/client/src/types.ts
@@ -27,6 +27,7 @@ export type WalletConnectorMetadata = Readonly<{
 	canAutoConnect?: boolean;
 	icon?: string;
 	id: string;
+	kind?: string;
 	name: string;
 	ready?: boolean;
 }>;

--- a/packages/client/src/wallet/standard.test.ts
+++ b/packages/client/src/wallet/standard.test.ts
@@ -1,0 +1,69 @@
+import * as walletApp from '@wallet-standard/app';
+import type { Wallet } from '@wallet-standard/base';
+import { StandardConnect } from '@wallet-standard/features';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { createWalletStandardConnector, getWalletStandardConnectors } from './standard';
+
+vi.mock('@wallet-standard/app', () => {
+	let wallets: Wallet[] = [];
+	return {
+		getWallets: () => ({
+			get: () => wallets,
+			on: vi.fn(),
+		}),
+		__setWallets(newWallets: Wallet[]) {
+			wallets = newWallets;
+		},
+	};
+});
+
+const mockApp = walletApp as unknown as { __setWallets: (wallets: Wallet[]) => void };
+
+function createStubWallet(name: string): Wallet {
+	const account = {
+		address: `${name}-address`,
+		chains: ['solana:devnet'],
+		features: [],
+		label: 'Primary',
+		publicKey: new Uint8Array([1, 2, 3]),
+	};
+	const connectFeature = {
+		connect: vi.fn(async () => ({ accounts: [account] })),
+	};
+	return {
+		accounts: [account],
+		features: {
+			[StandardConnect]: connectFeature,
+		},
+		name,
+		version: '1.0.0',
+	};
+}
+
+describe('Wallet Standard connector metadata', () => {
+	beforeEach(() => {
+		(globalThis as Record<string, unknown>).window = {};
+	});
+
+	it('sets a stable id, kind, and ready flag on connectors', () => {
+		const wallet = createStubWallet('Demo Wallet');
+		const connector = createWalletStandardConnector(wallet);
+
+		expect(connector.id).toBe('wallet-standard:demo-wallet');
+		expect(connector.kind).toBe('wallet-standard');
+		expect(connector.ready).toBe(true);
+		expect(connector.canAutoConnect).toBe(true);
+	});
+
+	it('deduplicates connectors by id when discovering wallets', () => {
+		const walletA = createStubWallet('Demo Wallet');
+		const walletB = createStubWallet('Demo Wallet'); // same name => same derived id
+
+		mockApp.__setWallets([walletA, walletB]);
+
+		const connectors = getWalletStandardConnectors();
+		expect(connectors).toHaveLength(1);
+		expect(connectors[0].id).toBe('wallet-standard:demo-wallet');
+	});
+});

--- a/packages/client/src/wallet/standard.ts
+++ b/packages/client/src/wallet/standard.ts
@@ -24,6 +24,7 @@ export type WalletStandardConnectorMetadata = Readonly<{
 	defaultChain?: IdentifierString;
 	icon?: string;
 	id?: string;
+	kind?: string;
 	name?: string;
 }>;
 
@@ -37,10 +38,11 @@ const transactionEncoder = getTransactionEncoder();
  * Derives a connector identifier from a wallet instance.
  *
  * @param wallet - Wallet whose name will be transformed into an identifier.
- * @returns Kebab-case identifier string derived from the wallet name.
+ * @returns Namespaced identifier string derived from the wallet name.
  */
 function deriveConnectorId(wallet: Wallet): string {
-	return wallet.name.toLowerCase().replace(/[^a-z0-9]+/g, '-');
+	const kebab = wallet.name.toLowerCase().replace(/[^a-z0-9]+/g, '-');
+	return `wallet-standard:${kebab}`;
 }
 
 /**
@@ -125,6 +127,7 @@ export function createWalletStandardConnector(
 		canAutoConnect: options.canAutoConnect ?? Boolean(wallet.features[StandardConnect]),
 		icon: options.icon ?? wallet.icon,
 		id: options.id ?? deriveConnectorId(wallet),
+		kind: options.kind ?? 'wallet-standard',
 		name: options.name ?? wallet.name,
 		ready: typeof window !== 'undefined',
 	};


### PR DESCRIPTION
## Summary
- add connector metadata tweaks: stable `wallet-standard:<name>` ids, `kind: 'wallet-standard'`, optional `ready`, and dedup on id
- add tests covering connector metadata and deduplication
- add changeset for patch release

Resolves #21.
