### PR TITLE
Stop publishing web3-compat for now

### DIFF
--- a/packages/web3-compat/README.md
+++ b/packages/web3-compat/README.md
@@ -5,6 +5,9 @@ code run on top of Kit primitives.
 
 This package is designed to help migrate from web3.js to Kit.
 
+> Status: this package is currently kept private inside the monorepo while we
+> finish parity testing. It is not published to npm yet.
+
 The goal of this release is **zero breaking changes** for applications that only
 touch the subset of web3.js APIs listed below. There will be future releases that slowly
 implement breaking changes as they move over to Kit primitives and intuitions.

--- a/packages/web3-compat/package.json
+++ b/packages/web3-compat/package.json
@@ -1,6 +1,7 @@
 {
 	"name": "@solana/web3-compat",
 	"version": "0.0.1",
+	"private": true,
 	"description": "Compatibility layer that preserves the web3.js API while delegating to Kit primitives under the hood",
 	"exports": {
 		"edge-light": {


### PR DESCRIPTION
## Summary
- keep @solana/web3-compat private so changeset publish no longer attempts to ship it
- document that it remains unpublished while parity testing finishes


Note, this is temporary while we change the NPM token to support the new web3-compat package