### PR TITLE
Add issue and PR templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,59 @@
+name: Bug report
+description: Report a reproducible bug with Framework Kit
+title: "[Bug]: <short summary>"
+labels: ["bug"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Please share a minimal public reproduction repo so we can debug quickly. Issues without a repro will be closed until a repro is provided.
+  - type: input
+    id: repro
+    attributes:
+      label: Minimal reproduction repo (required)
+      description: Link to a public repo/branch with the smallest possible reproduction and exact steps/commands to run it.
+      placeholder: "https://github.com/yourname/kit-repro"
+    validations:
+      required: true
+  - type: textarea
+    id: steps
+    attributes:
+      label: Steps to reproduce
+      description: Enumerate each step needed to hit the bug in the repro repo.
+      placeholder: |
+        1. ...
+        2. ...
+    validations:
+      required: true
+  - type: textarea
+    id: actual
+    attributes:
+      label: Actual behavior
+      description: What happened? Include stack traces, logs, or screenshots if helpful.
+    validations:
+      required: true
+  - type: textarea
+    id: expected
+    attributes:
+      label: Expected behavior
+      description: What should have happened instead?
+    validations:
+      required: true
+  - type: textarea
+    id: environment
+    attributes:
+      label: Environment
+      description: OS, Node version, package versions (`@solana/client`, `@solana/react-hooks`, `@solana/web3-compat` if applicable), runtime (browser/Node/edge), and any flags.
+      placeholder: |
+        - OS:
+        - Node:
+        - Package versions:
+        - Runtime (browser + version / Node / edge):
+        - Cluster / endpoint:
+    validations:
+      required: true
+  - type: textarea
+    id: extra
+    attributes:
+      label: Additional context
+      description: Anything else we should know?

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,2 @@
+blank_issues_enabled: false
+contact_links: []

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,0 +1,36 @@
+name: Feature request
+description: Suggest a new feature or significant improvement
+title: "[Feature]: <short summary>"
+labels: ["enhancement"]
+body:
+  - type: textarea
+    id: summary
+    attributes:
+      label: Summary
+      description: What you want to build or change.
+    validations:
+      required: true
+  - type: textarea
+    id: problem
+    attributes:
+      label: Problem to solve
+      description: What limitation or pain point does this address?
+    validations:
+      required: true
+  - type: textarea
+    id: proposal
+    attributes:
+      label: Proposed solution
+      description: Outline the approach or API you have in mind.
+    validations:
+      required: true
+  - type: textarea
+    id: alternatives
+    attributes:
+      label: Alternatives considered
+      description: Other options you evaluated and why they don’t work.
+  - type: textarea
+    id: context
+    attributes:
+      label: Additional context
+      description: Links, sketches, or related issues/PRs.

--- a/.github/ISSUE_TEMPLATE/maintenance.yml
+++ b/.github/ISSUE_TEMPLATE/maintenance.yml
@@ -1,0 +1,29 @@
+name: Maintenance / DX request
+description: Request refactors, docs cleanups, or developer-experience improvements
+title: "[Maintenance]: <short summary>"
+labels: ["chore"]
+body:
+  - type: textarea
+    id: summary
+    attributes:
+      label: Summary
+      description: What should be improved?
+    validations:
+      required: true
+  - type: textarea
+    id: motivation
+    attributes:
+      label: Motivation
+      description: Why this matters (clarity, reliability, performance, docs, etc.).
+    validations:
+      required: true
+  - type: textarea
+    id: scope
+    attributes:
+      label: Scope / constraints
+      description: Boundaries, non-goals, or rollout expectations.
+  - type: textarea
+    id: context
+    attributes:
+      label: Additional context
+      description: Related issues/PRs or examples.

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,8 @@
+## Summary
+- 
+
+## Testing
+- [ ] `pnpm lint`
+- [ ] `pnpm test`
+- [ ] `pnpm build`
+- [ ] Other (describe):


### PR DESCRIPTION
## Summary
- add issue forms for bugs (with required minimal repro), feature requests, and maintenance/dx tasks
- disable blank issues
- add a simple PR template with summary and testing checklist