### PR TITLE
Wire SerializableSolanaState hydration and persistence helpers

### DIFF
--- a/.changeset/ssr-serialization-wiring.md
+++ b/.changeset/ssr-serialization-wiring.md
@@ -1,0 +1,5 @@
+---
+"@solana/client": patch
+---
+
+Add SerializableSolanaState wiring: createClient accepts initialState, serialization helpers (serialize/deserialize/subscribe), and tests for hydration/persistence snapshots.

--- a/packages/client/src/client/createClient.test.ts
+++ b/packages/client/src/client/createClient.test.ts
@@ -143,6 +143,33 @@ describe('createClient', () => {
 		expect(createSolanaRpcClientMock).not.toHaveBeenCalled();
 	});
 
+	it('applies initialState overrides to config', () => {
+		const state = {
+			autoconnect: false,
+			commitment: 'processed',
+			endpoint: 'https://rpc.state',
+			lastConnectorId: null,
+			lastPublicKey: null,
+			version: 1,
+			websocketEndpoint: 'wss://rpc.state',
+		};
+		createClient({
+			...config,
+			endpoint: 'https://rpc.config',
+			initialState: state,
+		});
+		expect(createSolanaRpcClientMock).toHaveBeenCalledWith({
+			commitment: 'processed',
+			endpoint: 'https://rpc.state',
+			websocketEndpoint: 'wss://rpc.state',
+		});
+		const actions = createActionsMock.mock.results[createActionsMock.mock.results.length - 1].value as ActionSet;
+		expect(actions.setCluster).toHaveBeenCalledWith('https://rpc.state', {
+			commitment: 'processed',
+			websocketEndpoint: 'wss://rpc.state',
+		});
+	});
+
 	it('logs errors when initial cluster setup fails', async () => {
 		const logger = vi.fn();
 		createLoggerMock.mockReturnValueOnce(logger as Logger);

--- a/packages/client/src/index.ts
+++ b/packages/client/src/index.ts
@@ -65,7 +65,13 @@ export {
 	type SolanaRpcClient,
 } from './rpc/createSolanaRpcClient';
 export { bigintFromJson, bigintToJson, lamportsFromJson, lamportsToJson } from './serialization/json';
-export { applySerializableState, getInitialSerializableState } from './serialization/state';
+export {
+	applySerializableState,
+	deserializeSolanaState,
+	getInitialSerializableState,
+	serializeSolanaState,
+	subscribeSolanaState,
+} from './serialization/state';
 export {
 	type ConfirmationCommitment,
 	confirmationMeetsCommitment,

--- a/packages/client/src/serialization/state.test.ts
+++ b/packages/client/src/serialization/state.test.ts
@@ -1,7 +1,15 @@
+import type { Address } from '@solana/kit';
 import { describe, expect, it } from 'vitest';
 
-import type { SolanaClientConfig } from '../types';
-import { applySerializableState, getInitialSerializableState } from './state';
+import { createClientStore, createInitialClientState } from '../client/createClientStore';
+import type { SolanaClient, SolanaClientConfig } from '../types';
+import {
+	applySerializableState,
+	deserializeSolanaState,
+	getInitialSerializableState,
+	serializeSolanaState,
+	subscribeSolanaState,
+} from './state';
 
 const baseConfig: SolanaClientConfig = {
 	endpoint: 'https://api.devnet.solana.com',
@@ -48,6 +56,57 @@ describe('serialization state helpers', () => {
 			endpoint: 'https://api.mainnet-beta.solana.com',
 			commitment: 'confirmed',
 			websocketEndpoint: 'wss://example.com',
+		});
+	});
+
+	it('serializes and deserializes state safely', () => {
+		const state = getInitialSerializableState(baseConfig);
+		const json = serializeSolanaState(state);
+		expect(deserializeSolanaState(json)).toEqual(state);
+		expect(deserializeSolanaState('')).toBeNull();
+		expect(deserializeSolanaState('not-json')).toBeNull();
+	});
+
+	it('subscribes to client state changes and emits serializable snapshots', () => {
+		const initial = createInitialClientState({
+			commitment: 'confirmed',
+			endpoint: baseConfig.endpoint,
+			websocketEndpoint: `${baseConfig.endpoint.replace('https', 'wss')}`,
+		});
+		const store = createClientStore(initial);
+		const client = { store } as unknown as SolanaClient;
+
+		const snapshots: Array<ReturnType<typeof deserializeSolanaState>> = [];
+		const unsubscribe = subscribeSolanaState(client, (state) => snapshots.push(state));
+
+		store.setState((prev) => ({
+			...prev,
+			wallet: {
+				connectorId: 'phantom',
+				session: {
+					account: {
+						address: 'address' as unknown as Address,
+						publicKey: new Uint8Array(),
+					},
+					connector: { id: 'phantom', name: 'Phantom' },
+					disconnect: async () => undefined,
+				},
+				status: 'connected',
+			},
+		}));
+
+		unsubscribe();
+
+		expect(snapshots[0]).toMatchObject({
+			endpoint: baseConfig.endpoint,
+			commitment: 'confirmed',
+			websocketEndpoint: `${baseConfig.endpoint.replace('https', 'wss')}`,
+			lastConnectorId: null,
+			lastPublicKey: null,
+		});
+		expect(snapshots.at(-1)).toMatchObject({
+			lastConnectorId: 'phantom',
+			lastPublicKey: 'address',
 		});
 	});
 });

--- a/packages/client/src/types.ts
+++ b/packages/client/src/types.ts
@@ -163,6 +163,7 @@ export type SolanaClientConfig = Readonly<{
 	commitment?: Commitment;
 	createStore?: CreateStoreFn;
 	endpoint: ClusterUrl;
+	initialState?: SerializableSolanaState;
 	logger?: ClientLogger;
 	rpcClient?: SolanaRpcClient;
 	walletConnectors?: readonly WalletConnector[];


### PR DESCRIPTION
## Summary
- allow createClient to accept `initialState` and apply SerializableSolanaState when constructing runtime
- add serialize/deserialize/subscribe helpers for SerializableSolanaState, and export them
- add tests for hydration overrides and subscription snapshots; add changeset for patch release

Resolves #23.
