### PR TITLE
Enable publishing @solana/web3-compat

### DIFF
--- a/.changeset/config.json
+++ b/.changeset/config.json
@@ -11,5 +11,5 @@
 	"commit": false,
 	"linked": [],
 	"updateInternalDependencies": "patch",
-	"ignore": ["@solana/web3-compat", "@solana/web3-compat-parity-tests"]
+	"ignore": ["@solana/web3-compat-parity-tests"]
 }

--- a/.github/workflows/publish-packages.yml
+++ b/.github/workflows/publish-packages.yml
@@ -72,7 +72,7 @@ jobs:
         run: |
           pnpm changeset version --snapshot canary
           pnpm build
-          pnpm changeset publish --tag canary --filter @solana/client --filter @solana/react-hooks
+          pnpm changeset publish --tag canary --filter @solana/client --filter @solana/react-hooks --filter @solana/web3-compat
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
 		"prepare": "husky",
 		"changeset": "changeset",
 		"version:packages": "changeset version",
-		"publish-packages": "changeset publish --filter @solana/client --filter @solana/react-hooks"
+		"publish-packages": "changeset publish --filter @solana/client --filter @solana/react-hooks --filter @solana/web3-compat"
 	},
 	"devDependencies": {
 		"@changesets/changelog-github": "^0.5.1",

--- a/packages/web3-compat/README.md
+++ b/packages/web3-compat/README.md
@@ -5,9 +5,6 @@ code run on top of Kit primitives.
 
 This package is designed to help migrate from web3.js to Kit.
 
-> Status: this package is currently kept private inside the monorepo while we
-> finish parity testing. It is not published to npm yet.
-
 The goal of this release is **zero breaking changes** for applications that only
 touch the subset of web3.js APIs listed below. There will be future releases that slowly
 implement breaking changes as they move over to Kit primitives and intuitions.

--- a/packages/web3-compat/package.json
+++ b/packages/web3-compat/package.json
@@ -1,7 +1,6 @@
 {
 	"name": "@solana/web3-compat",
 	"version": "0.0.1",
-	"private": true,
 	"description": "Compatibility layer that preserves the web3.js API while delegating to Kit primitives under the hood",
 	"exports": {
 		"edge-light": {


### PR DESCRIPTION
## Summary
- mark @solana/web3-compat public again and remove the temporary README note
- allow versioning by removing it from changeset ignore list
- update publish scripts/workflow filters to include the package for regular and canary publishes