### PR TITLE
Set repository URL for web3-compat publish

### DIFF
--- a/packages/web3-compat/package.json
+++ b/packages/web3-compat/package.json
@@ -41,6 +41,10 @@
 		"kit",
 		"compatibility"
 	],
+	"repository": {
+		"type": "git",
+		"url": "https://github.com/solana-foundation/framework-kit"
+	},
 	"scripts": {
 		"build": "pnpm compile:js && pnpm compile:typedefs",
 		"compile:js": "tsup --config ../build-scripts/tsup.config.package.ts",


### PR DESCRIPTION
## Summary
- add repository metadata to @solana/web3-compat package.json so npm provenance validation matches the GitHub repo

This should unblock publishing by aligning the provenance repo URL with npm’s expectations.