### PR TITLE
Add typed client action wrappers

### DIFF
--- a/.changeset/friendly-jaguars-move.md
+++ b/.changeset/friendly-jaguars-move.md
@@ -1,0 +1,5 @@
+---
+"@solana/client": minor
+---
+
+Add typed Parameters/ReturnType aliases and client-first wrapper exports for all public actions.

--- a/packages/client/src/actions.test.ts
+++ b/packages/client/src/actions.test.ts
@@ -1,0 +1,95 @@
+import type { Address, ClusterUrl, Lamports, SendableTransaction, Signature, Transaction } from '@solana/kit';
+import type { TransactionWithLastValidBlockHeight } from '@solana/transaction-confirmation';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import {
+	connectWallet,
+	disconnectWallet,
+	fetchAccount,
+	fetchBalance,
+	requestAirdrop,
+	sendTransaction,
+	setCluster,
+} from './actions';
+import type { AccountCacheEntry, ClientActions, SolanaClient } from './types';
+
+describe('action wrappers', () => {
+	let actions: ClientActions;
+	let client: SolanaClient;
+	let fetchAccountResult: AccountCacheEntry;
+	let connectWalletMock: ReturnType<typeof vi.fn>;
+	let disconnectWalletMock: ReturnType<typeof vi.fn>;
+	let fetchBalanceMock: ReturnType<typeof vi.fn>;
+	let fetchAccountMock: ReturnType<typeof vi.fn>;
+	let requestAirdropMock: ReturnType<typeof vi.fn>;
+	let sendTransactionMock: ReturnType<typeof vi.fn>;
+	let setClusterMock: ReturnType<typeof vi.fn>;
+	const address = 'address' as Address;
+	const endpoint = 'https://rpc.test' as ClusterUrl;
+	const websocketEndpoint = 'wss://rpc.test' as ClusterUrl;
+	const lamports = 100n as Lamports;
+	const signature = 'sig' as Signature;
+	const airdropSignature = 'airdrop-sig' as Signature;
+	const transaction = { lastValidBlockHeight: 1n } as SendableTransaction &
+		Transaction &
+		TransactionWithLastValidBlockHeight;
+
+	beforeEach(() => {
+		connectWalletMock = vi.fn(async () => undefined);
+		disconnectWalletMock = vi.fn(async () => undefined);
+		fetchBalanceMock = vi.fn(async () => lamports);
+		fetchAccountMock = vi.fn(async () => fetchAccountResult);
+		requestAirdropMock = vi.fn(async () => airdropSignature);
+		sendTransactionMock = vi.fn(async () => signature);
+		setClusterMock = vi.fn(async () => undefined);
+
+		fetchAccountResult = {
+			address,
+			data: null,
+			error: undefined,
+			fetching: false,
+			lamports,
+			lastFetchedAt: 1,
+			slot: 1n,
+		};
+
+		actions = {
+			connectWallet: connectWalletMock,
+			disconnectWallet: disconnectWalletMock,
+			fetchAccount: fetchAccountMock,
+			fetchBalance: fetchBalanceMock,
+			requestAirdrop: requestAirdropMock,
+			sendTransaction: sendTransactionMock,
+			setCluster: setClusterMock,
+		};
+
+		client = { actions } as unknown as SolanaClient;
+	});
+
+	it('forwards parameters to client actions', async () => {
+		await connectWallet(client, { connectorId: 'wallet', options: { autoConnect: true } });
+		expect(connectWalletMock).toHaveBeenCalledWith('wallet', { autoConnect: true });
+
+		await disconnectWallet(client);
+		expect(disconnectWalletMock).toHaveBeenCalledWith();
+
+		const balanceResult = await fetchBalance(client, { address, commitment: 'processed' });
+		expect(fetchBalanceMock).toHaveBeenCalledWith(address, 'processed');
+		expect(balanceResult).toBe(lamports);
+
+		const accountResult = await fetchAccount(client, { address });
+		expect(fetchAccountMock).toHaveBeenCalledWith(address, undefined);
+		expect(accountResult).toBe(fetchAccountResult);
+
+		const dropSignature = await requestAirdrop(client, { address, lamports });
+		expect(requestAirdropMock).toHaveBeenCalledWith(address, lamports);
+		expect(dropSignature).toBe(airdropSignature);
+
+		const sentSignature = await sendTransaction(client, { commitment: 'finalized', transaction });
+		expect(sendTransactionMock).toHaveBeenCalledWith(transaction, 'finalized');
+		expect(sentSignature).toBe(signature);
+
+		await setCluster(client, { endpoint, config: { commitment: 'processed', websocketEndpoint } });
+		expect(setClusterMock).toHaveBeenCalledWith(endpoint, { commitment: 'processed', websocketEndpoint });
+	});
+});

--- a/packages/client/src/actions.ts
+++ b/packages/client/src/actions.ts
@@ -1,0 +1,49 @@
+import type {
+	ConnectWalletParameters,
+	ConnectWalletReturnType,
+	DisconnectWalletParameters,
+	DisconnectWalletReturnType,
+	FetchAccountParameters,
+	FetchAccountReturnType,
+	FetchBalanceParameters,
+	FetchBalanceReturnType,
+	RequestAirdropParameters,
+	RequestAirdropReturnType,
+	SendTransactionParameters,
+	SendTransactionReturnType,
+	SetClusterParameters,
+	SetClusterReturnType,
+	SolanaClient,
+} from './types';
+
+export function connectWallet(client: SolanaClient, params: ConnectWalletParameters): ConnectWalletReturnType {
+	return client.actions.connectWallet(params.connectorId, params.options);
+}
+
+export function disconnectWallet(
+	client: SolanaClient,
+	_params?: DisconnectWalletParameters,
+): DisconnectWalletReturnType {
+	void _params;
+	return client.actions.disconnectWallet();
+}
+
+export function fetchAccount(client: SolanaClient, params: FetchAccountParameters): FetchAccountReturnType {
+	return client.actions.fetchAccount(params.address, params.commitment);
+}
+
+export function fetchBalance(client: SolanaClient, params: FetchBalanceParameters): FetchBalanceReturnType {
+	return client.actions.fetchBalance(params.address, params.commitment);
+}
+
+export function requestAirdrop(client: SolanaClient, params: RequestAirdropParameters): RequestAirdropReturnType {
+	return client.actions.requestAirdrop(params.address, params.lamports);
+}
+
+export function sendTransaction(client: SolanaClient, params: SendTransactionParameters): SendTransactionReturnType {
+	return client.actions.sendTransaction(params.transaction, params.commitment);
+}
+
+export function setCluster(client: SolanaClient, params: SetClusterParameters): SetClusterReturnType {
+	return client.actions.setCluster(params.endpoint, params.config);
+}

--- a/packages/client/src/actions.typecheck.ts
+++ b/packages/client/src/actions.typecheck.ts
@@ -1,0 +1,107 @@
+import type {
+	Address,
+	ClusterUrl,
+	Commitment,
+	Lamports,
+	SendableTransaction,
+	Signature,
+	Transaction,
+} from '@solana/kit';
+import type { TransactionWithLastValidBlockHeight } from '@solana/transaction-confirmation';
+
+import type {
+	connectWallet,
+	disconnectWallet,
+	fetchAccount,
+	fetchBalance,
+	requestAirdrop,
+	sendTransaction,
+	setCluster,
+} from './actions';
+import type {
+	AccountCacheEntry,
+	ConnectWalletParameters,
+	ConnectWalletReturnType,
+	DisconnectWalletParameters,
+	DisconnectWalletReturnType,
+	FetchAccountParameters,
+	FetchAccountReturnType,
+	FetchBalanceParameters,
+	FetchBalanceReturnType,
+	RequestAirdropParameters,
+	RequestAirdropReturnType,
+	SendTransactionParameters,
+	SendTransactionReturnType,
+	SetClusterParameters,
+	SetClusterReturnType,
+	SolanaClient,
+} from './types';
+
+type Equal<A, B> = (<T>() => T extends A ? 1 : 2) extends <T>() => T extends B ? 1 : 2 ? true : false;
+type Expect<T extends true> = T;
+
+export type ConnectWalletParametersMatch = Expect<
+	Equal<ConnectWalletParameters, Readonly<{ connectorId: string; options?: Readonly<{ autoConnect?: boolean }> }>>
+>;
+export type ConnectWalletReturnMatch = Expect<Equal<ConnectWalletReturnType, Promise<void>>>;
+export type DisconnectWalletParametersMatch = Expect<Equal<DisconnectWalletParameters, undefined>>;
+export type DisconnectWalletReturnMatch = Expect<Equal<DisconnectWalletReturnType, Promise<void>>>;
+
+export type FetchAccountParametersMatch = Expect<
+	Equal<FetchAccountParameters, Readonly<{ address: Address; commitment?: Commitment }>>
+>;
+export type FetchAccountReturnMatch = Expect<Equal<FetchAccountReturnType, Promise<AccountCacheEntry>>>;
+
+export type FetchBalanceParametersMatch = Expect<
+	Equal<FetchBalanceParameters, Readonly<{ address: Address; commitment?: Commitment }>>
+>;
+export type FetchBalanceReturnMatch = Expect<Equal<FetchBalanceReturnType, Promise<Lamports>>>;
+
+export type RequestAirdropParametersMatch = Expect<
+	Equal<RequestAirdropParameters, Readonly<{ address: Address; lamports: Lamports }>>
+>;
+export type RequestAirdropReturnMatch = Expect<Equal<RequestAirdropReturnType, Promise<Signature>>>;
+
+export type SendTransactionParametersMatch = Expect<
+	Equal<
+		SendTransactionParameters,
+		Readonly<{
+			commitment?: Commitment;
+			transaction: SendableTransaction & Transaction & TransactionWithLastValidBlockHeight;
+		}>
+	>
+>;
+export type SendTransactionReturnMatch = Expect<Equal<SendTransactionReturnType, Promise<Signature>>>;
+
+export type SetClusterParametersMatch = Expect<
+	Equal<
+		SetClusterParameters,
+		Readonly<{
+			endpoint: ClusterUrl;
+			config?: Readonly<{ commitment?: Commitment; websocketEndpoint?: ClusterUrl }>;
+		}>
+	>
+>;
+export type SetClusterReturnMatch = Expect<Equal<SetClusterReturnType, Promise<void>>>;
+
+export type ConnectWalletWrapperSignature = Expect<
+	Equal<Parameters<typeof connectWallet>, [SolanaClient, ConnectWalletParameters]>
+>;
+export type DisconnectWalletWrapperSignature = Expect<
+	Equal<Parameters<typeof disconnectWallet>, [SolanaClient, DisconnectWalletParameters?]>
+>;
+export type FetchAccountWrapperSignature = Expect<
+	Equal<Parameters<typeof fetchAccount>, [SolanaClient, FetchAccountParameters]>
+>;
+export type FetchBalanceWrapperSignature = Expect<
+	Equal<Parameters<typeof fetchBalance>, [SolanaClient, FetchBalanceParameters]>
+>;
+export type RequestAirdropWrapperSignature = Expect<
+	Equal<Parameters<typeof requestAirdrop>, [SolanaClient, RequestAirdropParameters]>
+>;
+export type SendTransactionWrapperSignature = Expect<
+	Equal<Parameters<typeof sendTransaction>, [SolanaClient, SendTransactionParameters]>
+>;
+export type SetClusterWrapperSignature = Expect<
+	Equal<Parameters<typeof setCluster>, [SolanaClient, SetClusterParameters]>
+>;

--- a/packages/client/src/index.ts
+++ b/packages/client/src/index.ts
@@ -1,3 +1,12 @@
+export {
+	connectWallet,
+	disconnectWallet,
+	fetchAccount,
+	fetchBalance,
+	requestAirdrop,
+	sendTransaction,
+	setCluster,
+} from './actions';
 export { createClient } from './client/createClient';
 export { createClientStore, createDefaultClientStore, createInitialClientState } from './client/createClientStore';
 export {
@@ -114,7 +123,21 @@ export type {
 	ClientState,
 	ClientStore,
 	ClientWatchers,
+	ConnectWalletParameters,
+	ConnectWalletReturnType,
+	DisconnectWalletParameters,
+	DisconnectWalletReturnType,
+	FetchAccountParameters,
+	FetchAccountReturnType,
+	FetchBalanceParameters,
+	FetchBalanceReturnType,
+	RequestAirdropParameters,
+	RequestAirdropReturnType,
+	SendTransactionParameters,
+	SendTransactionReturnType,
 	SerializableSolanaState,
+	SetClusterParameters,
+	SetClusterReturnType,
 	SolanaClient,
 	SolanaClientConfig,
 	WalletConnector,

--- a/packages/client/src/types.ts
+++ b/packages/client/src/types.ts
@@ -205,20 +205,78 @@ export type WatchSubscription = Readonly<{
 	abort(): void;
 }>;
 
+export type ConnectWalletParameters = Readonly<{
+	connectorId: string;
+	options?: Readonly<{ autoConnect?: boolean }>;
+}>;
+
+export type ConnectWalletReturnType = Promise<void>;
+
+export type DisconnectWalletParameters = undefined;
+
+export type DisconnectWalletReturnType = Promise<void>;
+
+export type FetchAccountParameters = Readonly<{
+	address: Address;
+	commitment?: Commitment;
+}>;
+
+export type FetchAccountReturnType = Promise<AccountCacheEntry>;
+
+export type FetchBalanceParameters = Readonly<{
+	address: Address;
+	commitment?: Commitment;
+}>;
+
+export type FetchBalanceReturnType = Promise<Lamports>;
+
+export type RequestAirdropParameters = Readonly<{
+	address: Address;
+	lamports: Lamports;
+}>;
+
+export type RequestAirdropReturnType = Promise<Signature>;
+
+export type SendTransactionParameters = Readonly<{
+	commitment?: Commitment;
+	transaction: SendableTransaction & Transaction & TransactionWithLastValidBlockHeight;
+}>;
+
+export type SendTransactionReturnType = Promise<Signature>;
+
+export type SetClusterParameters = Readonly<{
+	config?: Readonly<{ commitment?: Commitment; websocketEndpoint?: ClusterUrl }>;
+	endpoint: ClusterUrl;
+}>;
+
+export type SetClusterReturnType = Promise<void>;
+
 export type ClientActions = Readonly<{
-	connectWallet(connectorId: string, options?: Readonly<{ autoConnect?: boolean }>): Promise<void>;
-	disconnectWallet(): Promise<void>;
-	fetchAccount(address: Address, commitment?: Commitment): Promise<AccountCacheEntry>;
-	fetchBalance(address: Address, commitment?: Commitment): Promise<Lamports>;
-	requestAirdrop(address: Address, lamports: Lamports): Promise<Signature>;
+	connectWallet(
+		connectorId: ConnectWalletParameters['connectorId'],
+		options?: ConnectWalletParameters['options'],
+	): ConnectWalletReturnType;
+	disconnectWallet(): DisconnectWalletReturnType;
+	fetchAccount(
+		address: FetchAccountParameters['address'],
+		commitment?: FetchAccountParameters['commitment'],
+	): FetchAccountReturnType;
+	fetchBalance(
+		address: FetchBalanceParameters['address'],
+		commitment?: FetchBalanceParameters['commitment'],
+	): FetchBalanceReturnType;
+	requestAirdrop(
+		address: RequestAirdropParameters['address'],
+		lamports: RequestAirdropParameters['lamports'],
+	): RequestAirdropReturnType;
 	sendTransaction(
-		transaction: SendableTransaction & Transaction & TransactionWithLastValidBlockHeight,
-		commitment?: Commitment,
-	): Promise<Signature>;
+		transaction: SendTransactionParameters['transaction'],
+		commitment?: SendTransactionParameters['commitment'],
+	): SendTransactionReturnType;
 	setCluster(
-		endpoint: ClusterUrl,
-		config?: Readonly<{ commitment?: Commitment; websocketEndpoint?: ClusterUrl }>,
-	): Promise<void>;
+		endpoint: SetClusterParameters['endpoint'],
+		config?: SetClusterParameters['config'],
+	): SetClusterReturnType;
 }>;
 
 export type ClientWatchers = Readonly<{


### PR DESCRIPTION
## Summary
- add typed Parameters/ReturnType aliases for public actions
- expose client-first wrappers and exports
- add wrapper tests and changeset

## Issue
- https://github.com/solana-foundation/framework-kit/issues/20

## Testing
- pnpm -C packages/client test:typecheck
- pnpm -C packages/client test