### PR TITLE
Avoid major release for react-hooks changeset

### DIFF
--- a/.changeset/bright-cycles-fold.md
+++ b/.changeset/bright-cycles-fold.md
@@ -1,5 +1,5 @@
 ---
-"@solana/react-hooks": major
+"@solana/react-hooks": minor
 ---
 
 Remove the Wallet Standard hook exports in favor of connector-driven flows. `useWalletConnection` prefers client-registered connectors and only falls back to discovery when none are configured; signing is done via connector-provided session methods instead of Wallet Standard packages.


### PR DESCRIPTION
Prevent an unintended major bump on @solana/react-hooks by downgrading the changeset to a minor release after removing the wallet standard hooks.