### PR TITLE
feat: use pnpm catalogs for core shared dependencies

### DIFF
--- a/.changeset/long-wings-ask.md
+++ b/.changeset/long-wings-ask.md
@@ -1,0 +1,8 @@
+---
+"@solana/react-hooks": patch
+"@solana/web3-compat": patch
+"@solana/test-types-smoke": patch
+"@solana/client": patch
+---
+
+centralize shared dependency versions using pnpm catalogs

--- a/packages/client/package.json
+++ b/packages/client/package.json
@@ -70,23 +70,23 @@
 	},
 	"license": "MIT",
 	"dependencies": {
-		"@solana/codecs-strings": "^5.0.0",
-		"@solana/kit": "^5.0.0",
-		"@solana/transactions": "^5.0.0",
-		"@solana/transaction-confirmation": "^5.0.0",
-		"@solana-program/system": "^0.9.0",
-		"@solana-program/compute-budget": "^0.9.0",
-		"@solana-program/token": "^0.5.1",
-		"@wallet-standard/app": "^1.0.1",
-		"@wallet-standard/base": "^1.1.0",
-		"@wallet-standard/errors": "^0.1.1",
-		"@wallet-standard/features": "^1.0.3",
-		"@solana/wallet-standard-features": "^1.3.0",
-		"bs58": "^6.0.0",
-		"zustand": "^5.0.0"
+		"@solana/codecs-strings": "catalog:solana",
+		"@solana/kit": "catalog:solana",
+		"@solana/transactions": "catalog:solana",
+		"@solana/transaction-confirmation": "catalog:solana",
+		"@solana-program/system": "catalog:solana",
+		"@solana-program/compute-budget": "catalog:solana",
+		"@solana-program/token": "catalog:solana",
+		"@wallet-standard/app": "catalog:solana",
+		"@wallet-standard/base": "catalog:solana",
+		"@wallet-standard/errors": "catalog:solana",
+		"@wallet-standard/features": "catalog:solana",
+		"@solana/wallet-standard-features": "catalog:solana",
+		"bs58": "catalog:utils",
+		"zustand": "catalog:utils"
 	},
 	"devDependencies": {
-		"@types/node": "^24"
+		"@types/node": "catalog:typescript"
 	},
 	"peerDependencies": {
 		"typescript": ">=5.3.3"

--- a/packages/react-hooks/package.json
+++ b/packages/react-hooks/package.json
@@ -59,21 +59,21 @@
 	"license": "MIT",
 	"dependencies": {
 		"@solana/client": "workspace:*",
-		"@solana/addresses": "^5.0.0",
-		"@solana/codecs-core": "^5.0.0",
-		"@solana/errors": "^5.0.0",
-		"@solana/keys": "^5.0.0",
-		"@solana/promises": "^5.0.0",
-		"@solana/signers": "^5.0.0",
-		"@solana/transaction-messages": "^5.0.0",
-		"@solana/transactions": "^5.0.0",
-		"@solana/kit": "^5.0.0",
+		"@solana/addresses": "catalog:solana",
+		"@solana/codecs-core": "catalog:solana",
+		"@solana/errors": "catalog:solana",
+		"@solana/keys": "catalog:solana",
+		"@solana/promises": "catalog:solana",
+		"@solana/signers": "catalog:solana",
+		"@solana/transaction-messages": "catalog:solana",
+		"@solana/transactions": "catalog:solana",
+		"@solana/kit": "catalog:solana",
 		"swr": "^2.3.6",
-		"zustand": "^5.0.0"
+		"zustand": "catalog:utils"
 	},
 	"devDependencies": {
-		"@types/react": "^19",
-		"react": "^19.0.0"
+		"@types/react": "catalog:typescript",
+		"react": "catalog:react"
 	},
 	"peerDependencies": {
 		"react": ">=18"

--- a/packages/web3-compat/package.json
+++ b/packages/web3-compat/package.json
@@ -57,16 +57,16 @@
 	},
 	"license": "MIT",
 	"dependencies": {
-		"@solana/compat": "^5.0.0",
-		"@solana/addresses": "^5.0.0",
+		"@solana/compat": "catalog:solana",
+		"@solana/addresses": "catalog:solana",
 		"@solana/client": "workspace:*",
-		"@solana/kit": "^5.0.0",
-		"@solana/transactions": "^5.0.0",
-		"@solana/web3.js": "^1.95.3",
-		"bs58": "^6.0.0"
+		"@solana/kit": "catalog:solana",
+		"@solana/transactions": "catalog:solana",
+		"@solana/web3.js": "catalog:solana",
+		"bs58": "catalog:utils"
 	},
 	"devDependencies": {
-		"@types/node": "^24"
+		"@types/node": "catalog:typescript"
 	},
 	"peerDependencies": {
 		"typescript": ">=5.3.3"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -4,6 +4,93 @@ settings:
   autoInstallPeers: true
   excludeLinksFromLockfile: false
 
+catalogs:
+  react:
+    react:
+      specifier: ^19.0.0
+      version: 19.2.0
+  solana:
+    '@solana-program/compute-budget':
+      specifier: ^0.9.0
+      version: 0.9.0
+    '@solana-program/system':
+      specifier: ^0.9.0
+      version: 0.9.0
+    '@solana-program/token':
+      specifier: ^0.5.1
+      version: 0.5.1
+    '@solana/addresses':
+      specifier: ^5.0.0
+      version: 5.0.0
+    '@solana/codecs-core':
+      specifier: ^5.0.0
+      version: 5.0.0
+    '@solana/codecs-strings':
+      specifier: ^5.0.0
+      version: 5.0.0
+    '@solana/compat':
+      specifier: ^5.0.0
+      version: 5.0.0
+    '@solana/errors':
+      specifier: ^5.0.0
+      version: 5.0.0
+    '@solana/keys':
+      specifier: ^5.0.0
+      version: 5.0.0
+    '@solana/kit':
+      specifier: ^5.0.0
+      version: 5.0.0
+    '@solana/promises':
+      specifier: ^5.0.0
+      version: 5.0.0
+    '@solana/signers':
+      specifier: ^5.0.0
+      version: 5.0.0
+    '@solana/transaction-confirmation':
+      specifier: ^5.0.0
+      version: 5.0.0
+    '@solana/transaction-messages':
+      specifier: ^5.0.0
+      version: 5.0.0
+    '@solana/transactions':
+      specifier: ^5.0.0
+      version: 5.0.0
+    '@solana/wallet-standard-features':
+      specifier: ^1.3.0
+      version: 1.3.0
+    '@solana/web3.js':
+      specifier: ^1.95.3
+      version: 1.98.4
+    '@wallet-standard/app':
+      specifier: ^1.0.1
+      version: 1.1.0
+    '@wallet-standard/base':
+      specifier: ^1.1.0
+      version: 1.1.0
+    '@wallet-standard/errors':
+      specifier: ^0.1.1
+      version: 0.1.1
+    '@wallet-standard/features':
+      specifier: ^1.0.3
+      version: 1.1.0
+  typescript:
+    '@types/node':
+      specifier: ^24
+      version: 24.10.0
+    '@types/react':
+      specifier: ^19.0.0
+      version: 19.2.2
+    typescript:
+      specifier: ^5.6.3
+      version: 5.9.3
+  utils:
+    bs58:
+      specifier: ^6.0.0
+      version: 6.0.0
+    zustand:
+      specifier: ^5.0.0
+      version: 5.0.8
+
 importers:
 
   .:
@@ -118,130 +205,130 @@ importers:
   packages/client:
     dependencies:
       '@solana-program/compute-budget':
-        specifier: ^0.9.0
+        specifier: catalog:solana
         version: 0.9.0(@solana/kit@5.0.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)(ws@8.18.3(bufferutil@4.0.9)(utf-8-validate@5.0.10)))
       '@solana-program/system':
-        specifier: ^0.9.0
+        specifier: catalog:solana
         version: 0.9.0(@solana/kit@5.0.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)(ws@8.18.3(bufferutil@4.0.9)(utf-8-validate@5.0.10)))
       '@solana-program/token':
-        specifier: ^0.5.1
+        specifier: catalog:solana
         version: 0.5.1(@solana/kit@5.0.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)(ws@8.18.3(bufferutil@4.0.9)(utf-8-validate@5.0.10)))
       '@solana/codecs-strings':
-        specifier: ^5.0.0
+        specifier: catalog:solana
         version: 5.0.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)
       '@solana/kit':
-        specifier: ^5.0.0
+        specifier: catalog:solana
         version: 5.0.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)(ws@8.18.3(bufferutil@4.0.9)(utf-8-validate@5.0.10))
       '@solana/transaction-confirmation':
-        specifier: ^5.0.0
+        specifier: catalog:solana
         version: 5.0.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)(ws@8.18.3(bufferutil@4.0.9)(utf-8-validate@5.0.10))
       '@solana/transactions':
-        specifier: ^5.0.0
+        specifier: catalog:solana
         version: 5.0.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)
       '@solana/wallet-standard-features':
-        specifier: ^1.3.0
+        specifier: catalog:solana
         version: 1.3.0
       '@wallet-standard/app':
-        specifier: ^1.0.1
+        specifier: catalog:solana
         version: 1.1.0
       '@wallet-standard/base':
-        specifier: ^1.1.0
+        specifier: catalog:solana
         version: 1.1.0
       '@wallet-standard/errors':
-        specifier: ^0.1.1
+        specifier: catalog:solana
         version: 0.1.1
       '@wallet-standard/features':
-        specifier: ^1.0.3
+        specifier: catalog:solana
         version: 1.1.0
       bs58:
-        specifier: ^6.0.0
+        specifier: catalog:utils
         version: 6.0.0
       typescript:
         specifier: '>=5.3.3'
         version: 5.9.3
       zustand:
-        specifier: ^5.0.0
+        specifier: catalog:utils
         version: 5.0.8(@types/react@19.2.2)(react@19.2.0)(use-sync-external-store@1.6.0(react@19.2.0))
     devDependencies:
       '@types/node':
-        specifier: ^24
+        specifier: catalog:typescript
         version: 24.10.0
 
   packages/react-hooks:
     dependencies:
       '@solana/addresses':
-        specifier: ^5.0.0
+        specifier: catalog:solana
         version: 5.0.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)
       '@solana/client':
         specifier: workspace:*
         version: link:../client
       '@solana/codecs-core':
-        specifier: ^5.0.0
+        specifier: catalog:solana
         version: 5.0.0(typescript@5.9.3)
       '@solana/errors':
-        specifier: ^5.0.0
+        specifier: catalog:solana
         version: 5.0.0(typescript@5.9.3)
       '@solana/keys':
-        specifier: ^5.0.0
+        specifier: catalog:solana
         version: 5.0.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)
       '@solana/kit':
-        specifier: ^5.0.0
+        specifier: catalog:solana
         version: 5.0.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)(ws@8.18.3(bufferutil@4.0.9)(utf-8-validate@5.0.10))
       '@solana/promises':
-        specifier: ^5.0.0
+        specifier: catalog:solana
         version: 5.0.0(typescript@5.9.3)
       '@solana/signers':
-        specifier: ^5.0.0
+        specifier: catalog:solana
         version: 5.0.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)
       '@solana/transaction-messages':
-        specifier: ^5.0.0
+        specifier: catalog:solana
         version: 5.0.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)
       '@solana/transactions':
-        specifier: ^5.0.0
+        specifier: catalog:solana
         version: 5.0.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)
       swr:
         specifier: ^2.3.6
         version: 2.3.6(react@19.2.0)
       zustand:
-        specifier: ^5.0.0
+        specifier: catalog:utils
         version: 5.0.8(@types/react@19.2.2)(react@19.2.0)(use-sync-external-store@1.6.0(react@19.2.0))
     devDependencies:
       '@types/react':
-        specifier: ^19
+        specifier: catalog:typescript
         version: 19.2.2
       react:
-        specifier: ^19.0.0
+        specifier: catalog:react
         version: 19.2.0
 
   packages/web3-compat:
     dependencies:
       '@solana/addresses':
-        specifier: ^5.0.0
+        specifier: catalog:solana
         version: 5.0.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)
       '@solana/client':
         specifier: workspace:*
         version: link:../client
       '@solana/compat':
-        specifier: ^5.0.0
+        specifier: catalog:solana
         version: 5.0.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)
       '@solana/kit':
-        specifier: ^5.0.0
+        specifier: catalog:solana
         version: 5.0.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)(ws@8.18.3(bufferutil@4.0.9)(utf-8-validate@5.0.10))
       '@solana/transactions':
-        specifier: ^5.0.0
+        specifier: catalog:solana
         version: 5.0.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)
       '@solana/web3.js':
-        specifier: ^1.95.3
+        specifier: catalog:solana
         version: 1.98.4(bufferutil@4.0.9)(typescript@5.9.3)(utf-8-validate@5.0.10)
       bs58:
-        specifier: ^6.0.0
+        specifier: catalog:utils
         version: 6.0.0
       typescript:
         specifier: '>=5.3.3'
         version: 5.9.3
     devDependencies:
       '@types/node':
-        specifier: ^24
+        specifier: catalog:typescript
         version: 24.10.0
 
   tests/types-smoke:
@@ -253,17 +340,17 @@ importers:
         specifier: workspace:*
         version: link:../../packages/react-hooks
       react:
-        specifier: ^19.0.0
+        specifier: catalog:react
         version: 19.2.0
     devDependencies:
       '@types/node':
-        specifier: ^24
+        specifier: catalog:typescript
         version: 24.10.0
       '@types/react':
-        specifier: ^19
+        specifier: catalog:typescript
         version: 19.2.2
       typescript:
-        specifier: ^5.6.3
+        specifier: catalog:typescript
         version: 5.9.3
 
   tests/web3-compat-parity-tests:

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -2,3 +2,44 @@ packages:
   - "packages/*"
   - "examples/*"
   - "tests/*"
+
+catalogs:
+  # Solana ecosystem packages
+  solana:
+    "@solana/compat": "^5.0.0"
+    "@solana/kit": "^5.0.0"
+    "@solana/addresses": "^5.0.0"
+    "@solana/codecs-core": "^5.0.0"
+    "@solana/codecs-strings": "^5.0.0"
+    "@solana/errors": "^5.0.0"
+    "@solana/keys": "^5.0.0"
+    "@solana/promises": "^5.0.0"
+    "@solana/signers": "^5.0.0"
+    "@solana/transactions": "^5.0.0"
+    "@solana/transaction-confirmation": "^5.0.0"
+    "@solana/transaction-messages": "^5.0.0"
+    "@solana-program/system": "^0.9.0"
+    "@solana-program/compute-budget": "^0.9.0"
+    "@solana-program/token": "^0.5.1"
+    "@wallet-standard/app": "^1.0.1"
+    "@wallet-standard/base": "^1.1.0"
+    "@wallet-standard/errors": "^0.1.1"
+    "@wallet-standard/features": "^1.0.3"
+    "@solana/wallet-standard-features": "^1.3.0"
+    "@solana/web3.js": "^1.95.3"
+
+  # Type definitions and TS ecosystem
+  typescript:
+    "typescript": "^5.6.3"
+    "@types/node": "^24"
+    "@types/react": "^19.0.0"
+
+  # UI / React ecosystem
+  react:
+    "react": "^19.0.0"
+    "react-dom": "^19.0.0"
+
+  # Shared utilities (only if used widely)
+  utils:
+    "bs58": "^6.0.0"
+    "zustand": "^5.0.0"

--- a/tests/types-smoke/package.json
+++ b/tests/types-smoke/package.json
@@ -11,11 +11,11 @@
 	"dependencies": {
 		"@solana/client": "workspace:*",
 		"@solana/react-hooks": "workspace:*",
-		"react": "^19.0.0"
+		"react": "catalog:react"
 	},
 	"devDependencies": {
-		"@types/node": "^24",
-		"@types/react": "^19",
-		"typescript": "^5.6.3"
+		"@types/node": "catalog:typescript",
+		"@types/react": "catalog:typescript",
+		"typescript": "catalog:typescript"
 	}
 }


### PR DESCRIPTION
## Summary

Centralized a set of cross-cutting production dependencies using pnpm catalogs to reduce version drift and simplify dependency upgrades across the monorepo. 

## Scope
- Add `catalogs:` entries to `pnpm-workspace.yaml` for:  `solana` (core libs), `typescript`, `react` and small `utils`.
- Update package.json files respectively to refer catalogs.
- No code, runtime, or API changes. On package build `catalog:*` is replaced with exact specified versions from the catalog.
- Kept `peerDependencies` relaxed as it was.

## Testing
- [x] `pnpm lint`
- [x] `pnpm test`
- [x] `pnpm build`
- [x] Fresh install

Closes https://github.com/solana-foundation/framework-kit/issues/54
