### PR TITLE
Add dependency audit workflow

### DIFF
--- a/.github/workflows/dependency-audit.yml
+++ b/.github/workflows/dependency-audit.yml
@@ -1,0 +1,20 @@
+name: Dependency Audit
+
+on:
+  pull_request:
+
+jobs:
+  audit:
+    name: Audit Dependencies
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Install dependencies
+        uses: ./.github/workflows/actions/install-dependencies
+        with:
+          version: 24
+
+      - name: Run pnpm audit
+        run: pnpm audit --prod


### PR DESCRIPTION
## Summary
- add dependency-audit workflow that runs pnpm audit --prod on PRs using shared install composite action (Node 24)

## Testing
- [ ] `pnpm lint`
- [ ] `pnpm test`
- [ ] `pnpm build`
- [ ] Other (describe): not run (CI-only change)