### PR TITLE
Fix tests for default client config

### DIFF
--- a/packages/client/src/client/createClient.test.ts
+++ b/packages/client/src/client/createClient.test.ts
@@ -102,7 +102,7 @@ describe('createClient', () => {
 		expect(createSolanaRpcClientMock).toHaveBeenCalledWith({
 			commitment: 'finalized',
 			endpoint: 'https://rpc.example',
-			websocketEndpoint: 'https://rpc.example',
+			websocketEndpoint: 'wss://rpc.example',
 		});
 		expect(createWalletRegistryMock).toHaveBeenCalledWith(config.walletConnectors);
 		expect(createActionsMock).toHaveBeenCalled();
@@ -112,7 +112,7 @@ describe('createClient', () => {
 		const actions = createActionsMock.mock.results[0].value as ActionSet;
 		expect(actions.setCluster).toHaveBeenCalledWith('https://rpc.example', {
 			commitment: 'finalized',
-			websocketEndpoint: 'https://rpc.example',
+			websocketEndpoint: 'wss://rpc.example',
 		});
 
 		const helpers = createClientHelpersMock.mock.results[0].value as Helpers;

--- a/packages/react-hooks/src/context.test.tsx
+++ b/packages/react-hooks/src/context.test.tsx
@@ -29,16 +29,6 @@ describe('SolanaClientProvider', () => {
 		vi.clearAllMocks();
 	});
 
-	it('throws when neither a client nor config is provided', () => {
-		expect(() =>
-			render(
-				<SolanaClientProvider>
-					<div />
-				</SolanaClientProvider>,
-			),
-		).toThrowError('SolanaClientProvider requires either a `client` or `config` prop.');
-	});
-
 	it('reuses the provided client instance and does not destroy it on unmount', () => {
 		const client = createMockSolanaClient();
 		const { result, unmount } = renderHookWithClient(() => useSolanaClient(), { client });
@@ -64,7 +54,33 @@ describe('SolanaClientProvider', () => {
 			</SolanaClientProvider>,
 		);
 
-		expect(createClientMock).toHaveBeenCalledWith(config);
+		expect(createClientMock).toHaveBeenCalledWith(
+			expect.objectContaining({
+				endpoint: 'http://localhost:8899',
+				websocketEndpoint: 'ws://localhost:8899',
+			}),
+		);
+
+		unmount();
+		expect(client.destroy).toHaveBeenCalledTimes(1);
+	});
+
+	it('creates a default client when neither client nor config is provided and cleans up on unmount', () => {
+		const client = createMockSolanaClient();
+		createClientMock.mockReturnValue(client);
+
+		const { unmount } = render(
+			<SolanaClientProvider>
+				<TestConsumer />
+			</SolanaClientProvider>,
+		);
+
+		expect(createClientMock).toHaveBeenCalledWith(
+			expect.objectContaining({
+				endpoint: 'https://api.devnet.solana.com',
+				websocketEndpoint: 'wss://api.devnet.solana.com',
+			}),
+		);
 
 		unmount();
 		expect(client.destroy).toHaveBeenCalledTimes(1);


### PR DESCRIPTION
## Summary
- update createClient and SolanaClientProvider tests to expect inferred websocket endpoints (wss/ws) and default devnet config
- adjust provider tests to reflect new default client creation instead of throwing when no config

## Testing
- [x] `pnpm --filter @solana/client test`
- [x] `pnpm lint`
- [x] `pnpm test`
- [x] `pnpm build`
- [ ] Other (describe):