### PR TITLE
Persist autoConnect preference and bump rc.1

### DIFF
--- a/.changeset/pre.json
+++ b/.changeset/pre.json
@@ -1,14 +1,16 @@
 {
-	"mode": "pre",
-	"tag": "rc",
-	"initialVersions": {
-		"@solana/example-nextjs": "0.0.0",
-		"@solana/example-vite-react": "0.0.11",
-		"@solana/client": "0.2.2",
-		"@solana/react-hooks": "0.5.0",
-		"@solana/web3-compat": "0.0.5",
-		"@solana/test-types-smoke": "0.0.10",
-		"@solana/web3-compat-parity-tests": "0.0.0"
-	},
-	"changesets": ["rc-v1-launch"]
+  "mode": "pre",
+  "tag": "rc",
+  "initialVersions": {
+    "@solana/example-nextjs": "0.0.0",
+    "@solana/example-vite-react": "0.0.11",
+    "@solana/client": "0.2.2",
+    "@solana/react-hooks": "0.5.0",
+    "@solana/web3-compat": "0.0.5",
+    "@solana/test-types-smoke": "0.0.10",
+    "@solana/web3-compat-parity-tests": "0.0.0"
+  },
+  "changesets": [
+    "rc-1-bump"
+  ]
 }

--- a/.changeset/rc-1-bump.md
+++ b/.changeset/rc-1-bump.md
@@ -1,0 +1,6 @@
+---
+'@solana/client': patch
+'@solana/react-hooks': patch
+---
+
+Persist wallet auto-connect preference coming from `connect()` options so provider defaults no longer override per-connection settings.

--- a/examples/nextjs/CHANGELOG.md
+++ b/examples/nextjs/CHANGELOG.md
@@ -1,5 +1,13 @@
 # @solana/example-nextjs
 
+## 0.0.1-rc.1
+
+### Patch Changes
+
+- Updated dependencies []:
+  - @solana/client@1.0.0-rc.1
+  - @solana/react-hooks@1.0.0-rc.1
+
 ## 0.0.1-rc.0
 
 ### Patch Changes

--- a/examples/nextjs/package.json
+++ b/examples/nextjs/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "@solana/example-nextjs",
 	"private": true,
-	"version": "0.0.1-rc.0",
+	"version": "0.0.1-rc.1",
 	"type": "module",
 	"scripts": {
 		"dev": "next dev",

--- a/examples/vite-react/CHANGELOG.md
+++ b/examples/vite-react/CHANGELOG.md
@@ -1,5 +1,13 @@
 # @solana/example-vite-react
 
+## 0.0.12-rc.1
+
+### Patch Changes
+
+- Updated dependencies []:
+  - @solana/client@1.0.0-rc.1
+  - @solana/react-hooks@1.0.0-rc.1
+
 ## 0.0.12-rc.0
 
 ### Patch Changes

--- a/examples/vite-react/package.json
+++ b/examples/vite-react/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "@solana/example-vite-react",
- "private": true,
-	"version": "0.0.12-rc.0",
+	"private": true,
+	"version": "0.0.12-rc.1",
 	"type": "module",
 	"scripts": {
 		"dev": "vite",

--- a/packages/client/CHANGELOG.md
+++ b/packages/client/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @solana/client
 
+## 1.0.0-rc.1
+
+### Patch Changes
+
+- Persist wallet auto-connect preference coming from `connect()` options so provider defaults no longer override per-connection settings.
+
 ## 1.0.0-rc.0
 
 ### Major Changes

--- a/packages/client/package.json
+++ b/packages/client/package.json
@@ -1,6 +1,6 @@
 {
- "name": "@solana/client",
-	"version": "1.0.0-rc.0",
+	"name": "@solana/client",
+	"version": "1.0.0-rc.1",
 	"description": "Framework-agnostic Solana client orchestration layer powering higher-level experiences",
 	"exports": {
 		".": {

--- a/packages/client/src/client/actions.ts
+++ b/packages/client/src/client/actions.ts
@@ -164,17 +164,18 @@ export function createActions({ connectors, logger: inputLogger, runtime, store 
 		if (!connector.isSupported()) {
 			throw new Error(`Wallet connector "${connectorId}" is not supported in this environment.`);
 		}
+		const autoConnectPreference = options.autoConnect ?? true;
 		store.setState((state) => ({
 			...state,
 			lastUpdatedAt: now(),
-			wallet: { connectorId, status: 'connecting' },
+			wallet: { autoConnect: autoConnectPreference, connectorId, status: 'connecting' },
 		}));
 		try {
 			const session = await connector.connect(options);
 			store.setState((state) => ({
 				...state,
 				lastUpdatedAt: now(),
-				wallet: { connectorId, session, status: 'connected' },
+				wallet: { autoConnect: autoConnectPreference, connectorId, session, status: 'connected' },
 			}));
 			logger({
 				data: { address: session.account.address.toString(), connectorId },
@@ -185,7 +186,7 @@ export function createActions({ connectors, logger: inputLogger, runtime, store 
 			store.setState((state) => ({
 				...state,
 				lastUpdatedAt: now(),
-				wallet: { connectorId, error, status: 'error' },
+				wallet: { autoConnect: autoConnectPreference, connectorId, error, status: 'error' },
 			}));
 			logger({
 				data: { connectorId, ...formatError(error) },

--- a/packages/client/src/serialization/state.ts
+++ b/packages/client/src/serialization/state.ts
@@ -70,7 +70,8 @@ export function deserializeSolanaState(json: string | null | undefined): Seriali
 
 function getSerializableStateSnapshot(client: SolanaClient): SerializableSolanaState {
 	const state = client.store.getState();
-	const wallet = state.wallet;
+	const wallet = state.wallet as typeof state.wallet & { autoConnect?: boolean };
+	const autoConnectPreference = wallet.autoConnect;
 	let lastConnectorId: string | null = null;
 	let lastPublicKey: string | null = null;
 	if ('connectorId' in wallet) {
@@ -80,7 +81,7 @@ function getSerializableStateSnapshot(client: SolanaClient): SerializableSolanaS
 		}
 	}
 	return {
-		autoconnect: Boolean(lastConnectorId),
+		autoconnect: autoConnectPreference ?? Boolean(lastConnectorId),
 		commitment: state.cluster.commitment,
 		endpoint: state.cluster.endpoint,
 		lastConnectorId,

--- a/packages/client/src/types.ts
+++ b/packages/client/src/types.ts
@@ -58,12 +58,14 @@ export type WalletConnector = WalletConnectorMetadata & {
 };
 
 type WalletStatusConnected = Readonly<{
+	autoConnect?: boolean;
 	connectorId: string;
 	session: WalletSession;
 	status: 'connected';
 }>;
 
 type WalletStatusConnecting = Readonly<{
+	autoConnect?: boolean;
 	connectorId: string;
 	status: 'connecting';
 }>;
@@ -73,6 +75,7 @@ type WalletStatusDisconnected = Readonly<{
 }>;
 
 type WalletStatusError = Readonly<{
+	autoConnect?: boolean;
 	connectorId?: string;
 	error: unknown;
 	status: 'error';

--- a/packages/react-hooks/CHANGELOG.md
+++ b/packages/react-hooks/CHANGELOG.md
@@ -1,5 +1,14 @@
 # @solana/react-hooks
 
+## 1.0.0-rc.1
+
+### Patch Changes
+
+- Persist wallet auto-connect preference coming from `connect()` options so provider defaults no longer override per-connection settings.
+
+- Updated dependencies []:
+  - @solana/client@1.0.0-rc.1
+
 ## 1.0.0-rc.0
 
 ### Major Changes

--- a/packages/react-hooks/package.json
+++ b/packages/react-hooks/package.json
@@ -1,6 +1,6 @@
 {
- "name": "@solana/react-hooks",
-	"version": "1.0.0-rc.0",
+	"name": "@solana/react-hooks",
+	"version": "1.0.0-rc.1",
 	"description": "React hooks for the @solana/client Solana client",
 	"exports": {
 		"edge-light": {

--- a/packages/web3-compat/CHANGELOG.md
+++ b/packages/web3-compat/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @solana/web3-compat
 
+## 0.0.6-rc.1
+
+### Patch Changes
+
+- Updated dependencies []:
+  - @solana/client@1.0.0-rc.1
+
 ## 0.0.6-rc.0
 
 ### Patch Changes

--- a/packages/web3-compat/package.json
+++ b/packages/web3-compat/package.json
@@ -1,6 +1,6 @@
 {
- "name": "@solana/web3-compat",
-	"version": "0.0.6-rc.0",
+	"name": "@solana/web3-compat",
+	"version": "0.0.6-rc.1",
 	"description": "Compatibility layer that preserves the web3.js API while delegating to Kit primitives under the hood",
 	"exports": {
 		"edge-light": {
@@ -56,7 +56,7 @@
 		"typecheck": "pnpm test:typecheck"
 	},
 	"license": "MIT",
- "dependencies": {
+	"dependencies": {
 		"@solana/compat": "catalog:solana",
 		"@solana/addresses": "catalog:solana",
 		"@solana/client": "workspace:*",

--- a/tests/types-smoke/CHANGELOG.md
+++ b/tests/types-smoke/CHANGELOG.md
@@ -1,5 +1,13 @@
 # @solana/test-types-smoke
 
+## 0.0.11-rc.1
+
+### Patch Changes
+
+- Updated dependencies []:
+  - @solana/client@1.0.0-rc.1
+  - @solana/react-hooks@1.0.0-rc.1
+
 ## 0.0.11-rc.0
 
 ### Patch Changes

--- a/tests/types-smoke/package.json
+++ b/tests/types-smoke/package.json
@@ -1,6 +1,6 @@
 {
- "name": "@solana/test-types-smoke",
-	"version": "0.0.11-rc.0",
+	"name": "@solana/test-types-smoke",
+	"version": "0.0.11-rc.1",
 	"private": true,
 	"type": "module",
 	"scripts": {


### PR DESCRIPTION
## Summary
- persist connect() autoConnect preference through wallet state/serialization so provider defaults don’t override per-connection settings
- add regression coverage
- bump packages to 1.0.0-rc.1 prerelease

## Testing
- pnpm vitest packages/client/src/serialization/state.test.ts