### PR TITLE
Docs: hook examples, hydration guard, and RC changeset

### DIFF
--- a/.changeset/rc-2-docs-and-hydration.md
+++ b/.changeset/rc-2-docs-and-hydration.md
@@ -1,0 +1,6 @@
+---
+'@solana/react-hooks': patch
+'@solana/client': patch
+---
+
+Improve docs for all hooks, add SSR-safe connector hydration in `useWalletConnection`, and document client actions with JSDoc for clearer usage.

--- a/packages/client/src/actions.ts
+++ b/packages/client/src/actions.ts
@@ -16,10 +16,21 @@ import type {
 	SolanaClient,
 } from './types';
 
+/**
+ * Connect to a registered wallet connector by id.
+ *
+ * @param client - Solana client instance.
+ * @param params - Connector id and optional auto-connect preference.
+ */
 export function connectWallet(client: SolanaClient, params: ConnectWalletParameters): ConnectWalletReturnType {
 	return client.actions.connectWallet(params.connectorId, params.options);
 }
 
+/**
+ * Disconnect the active wallet session (noop if already disconnected).
+ *
+ * @param client - Solana client instance.
+ */
 export function disconnectWallet(
 	client: SolanaClient,
 	_params?: DisconnectWalletParameters,
@@ -28,22 +39,52 @@ export function disconnectWallet(
 	return client.actions.disconnectWallet();
 }
 
+/**
+ * Fetch and cache account data for an address.
+ *
+ * @param client - Solana client instance.
+ * @param params - Address and optional commitment override.
+ */
 export function fetchAccount(client: SolanaClient, params: FetchAccountParameters): FetchAccountReturnType {
 	return client.actions.fetchAccount(params.address, params.commitment);
 }
 
+/**
+ * Fetch and cache lamport balance for an address.
+ *
+ * @param client - Solana client instance.
+ * @param params - Address and optional commitment override.
+ */
 export function fetchBalance(client: SolanaClient, params: FetchBalanceParameters): FetchBalanceReturnType {
 	return client.actions.fetchBalance(params.address, params.commitment);
 }
 
+/**
+ * Request an airdrop to an address.
+ *
+ * @param client - Solana client instance.
+ * @param params - Target address and lamports amount.
+ */
 export function requestAirdrop(client: SolanaClient, params: RequestAirdropParameters): RequestAirdropReturnType {
 	return client.actions.requestAirdrop(params.address, params.lamports);
 }
 
+/**
+ * Send a prepared transaction through the client.
+ *
+ * @param client - Solana client instance.
+ * @param params - Transaction and optional commitment override.
+ */
 export function sendTransaction(client: SolanaClient, params: SendTransactionParameters): SendTransactionReturnType {
 	return client.actions.sendTransaction(params.transaction, params.commitment);
 }
 
+/**
+ * Reconfigure the client to target a new cluster endpoint (and optional websocket/commitment).
+ *
+ * @param client - Solana client instance.
+ * @param params - Endpoint plus optional config overrides.
+ */
 export function setCluster(client: SolanaClient, params: SetClusterParameters): SetClusterReturnType {
 	return client.actions.setCluster(params.endpoint, params.config);
 }

--- a/packages/react-hooks/README.md
+++ b/packages/react-hooks/README.md
@@ -1,432 +1,316 @@
 # @solana/react-hooks
 
-React hooks for `@solana/client`. Drop in the provider and call hooks instead of juggling RPC
-clients, wallets, and stores yourself.
-
-> **Status:** Experimental – breaking changes may land often.
+React hooks for `@solana/client`. Wrap your app once and reach for hooks instead of wiring RPC, wallets, and stores by hand.
 
 ## Install
 
 ```bash
-pnpm add @solana/react-hooks
+npm install @solana/client @solana/react-hooks
 ```
 
-## Minimal example
+## Quickstart
 
-Build connectors first, create a client, and hand it to the combined provider.
+1. Choose wallet connectors (auto-discovery is the fastest way to start).
+2. Create a Solana client.
+3. Wrap your tree with `SolanaProvider` and use the hooks.
 
 ```tsx
-import { autoDiscover, backpack, createClient, phantom, solflare } from '@solana/client';
-import { SolanaProvider, useBalance, useConnectWallet, useWallet } from '@solana/react-hooks';
+import { autoDiscover, createClient } from "@solana/client";
+import {
+  SolanaProvider,
+  useBalance,
+  useWalletConnection,
+} from "@solana/react-hooks";
 
-const walletConnectors = [...phantom(), ...solflare(), ...backpack(), ...autoDiscover()];
 const client = createClient({
-    endpoint: 'https://api.devnet.solana.com',
-    websocketEndpoint: 'wss://api.devnet.solana.com',
-    walletConnectors,
+  endpoint: "https://api.devnet.solana.com",
+  walletConnectors: autoDiscover(),
 });
-
-function WalletButton() {
-    const connectWallet = useConnectWallet();
-    return <button onClick={() => connectWallet('phantom')}>Connect Phantom</button>;
-}
-
-function WalletBalance() {
-    const wallet = useWallet();
-    const balance = useBalance(wallet.status === 'connected' ? wallet.session.account.address : undefined);
-
-    if (wallet.status !== 'connected') return <p>Connect a wallet</p>;
-    if (balance.fetching) return <p>Loading…</p>;
-
-    return <p>Lamports: {balance.lamports?.toString() ?? '0'}</p>;
-}
 
 export function App() {
-    return (
-        <SolanaProvider client={client} query={{ suspense: true }}>
-            <WalletButton />
-            <WalletBalance />
-        </SolanaProvider>
-    );
+  return (
+    <SolanaProvider client={client}>
+      {/* your components that call hooks go here */}
+    </SolanaProvider>
+  );
 }
 ```
 
-`SolanaProvider` composes `SolanaClientProvider` and `SolanaQueryProvider` with SWR v2-aligned defaults
-(`revalidateOnFocus`/`revalidateOnReconnect`/`revalidateIfStale` are `true`, `dedupingInterval` is `2000`,
-`focusThrottleInterval` is `5000`). Override them via the `query.config` prop or per-hook `swr` options.
-Prefer passing a `client`; `config`-based setup on `SolanaClientProvider` is still available for bespoke
-composition.
+> **Next.js / RSC:** Components that call these hooks must be marked with `'use client'`.
 
-Every hook exposes `UseHookNameParameters` / `UseHookNameReturnType` aliases so wrapper components stay in
-sync with the public API.
+## Common Solana flows (copy/paste)
 
-## Hooks at a glance
+These snippets assume a parent already handled wallet connection and can pass an address where needed.
 
-- `useWallet`, `useConnectWallet`, `useDisconnectWallet` – read or update the current wallet session.
-- `useBalance` / `useAccount` – fetch lamports once or keep account data in sync.
-- `useSolTransfer`, `useSplToken`, `useTransactionPool` – helper-driven flows for SOL, SPL, and
-  general transactions.
-- `useSendTransaction` – prepare and submit arbitrary instructions with shared mutation state.
-- `useSignatureStatus`, `useWaitForSignature` – declarative helpers for tracking confirmations.
-- `useClientStore` – access the underlying Zustand store if you need low-level state.
-
-### Wallet helpers
-
-Read the current wallet session and expose connect/disconnect buttons.
+### Connect, disconnect, and show balance
 
 ```tsx
-const WalletActions = () => {
-    const wallet = useWallet();
-    const connect = useConnectWallet();
-    const disconnect = useDisconnectWallet();
+function WalletPanel() {
+  const { connectors, connect, disconnect, wallet, status } =
+    useWalletConnection();
+  const address = wallet?.account.address;
+  const balance = useBalance(address);
 
-    if (wallet.status === 'connected') {
-        return (
-            <div>
-                <p>{wallet.session.account.address.toString()}</p>
-                <button onClick={() => disconnect()}>Disconnect</button>
-            </div>
-        );
-    }
-
-    return <button onClick={() => connect('phantom')}>Connect Phantom</button>;
-};
-```
-
-### Balance watcher
-
-Read lamports (cached plus live updates) for any address.
-
-```tsx
-import { useBalance } from '@solana/react-hooks';
-
-function BalanceCard({ address }) {
-    const { lamports, fetching, slot } = useBalance(address);
-    if (fetching) return <p>Loading…</p>;
+  if (status === "connected") {
     return (
-        <div>
-            <p>Lamports: {lamports?.toString() ?? '0'}</p>
-            <small>Last slot: {slot?.toString() ?? 'unknown'}</small>
-        </div>
+      <div>
+        <p>{address?.toString()}</p>
+        <p>Lamports: {balance.lamports?.toString() ?? "loading…"}</p>
+        <button onClick={disconnect}>Disconnect</button>
+      </div>
     );
+  }
+
+  return connectors.map((c) => (
+    <button key={c.id} onClick={() => connect(c.id)}>
+      Connect {c.name}
+    </button>
+  ));
 }
 ```
 
-### Account cache
-
-Fetch account data and optionally keep it in sync via subscriptions.
+### Read lamport balance (auto fetch + watch)
 
 ```tsx
-import { useAccount } from '@solana/react-hooks';
+import { useBalance } from "@solana/react-hooks";
 
-function AccountInspector({ address }) {
-    const account = useAccount(address, { watch: true });
-
-    if (!account) return <p>Loading…</p>;
-    if (account.error) return <p>Error loading account</p>;
-
-    return <pre>{JSON.stringify(account.data, null, 2)}</pre>;
+function BalanceCard({ address }: { address: string }) {
+  const { lamports, fetching, slot } = useBalance(address);
+  if (fetching) return <p>Loading…</p>;
+  return (
+    <p>
+      Lamports: {lamports?.toString() ?? "0"} (slot {slot?.toString() ?? "—"})
+    </p>
+  );
 }
 ```
 
-### SOL transfers
-
-Trigger SOL transfers with built-in status tracking.
+### Send SOL
 
 ```tsx
-import { useSolTransfer } from '@solana/react-hooks';
+import { useSolTransfer } from "@solana/react-hooks";
 
-const SendSolButton = ({ destination, amount }) => {
-    const { send, isSending } = useSolTransfer();
-
-    return (
-        <button
-            disabled={isSending}
-            onClick={() =>
-                send({
-                    destination,
-                    lamports: amount,
-                })
-            }
-        >
-            {isSending ? 'Sending…' : 'Send SOL'}
-        </button>
-    );
-};
-```
-
-### SPL tokens
-
-Scope SPL helpers by mint and reuse the same API for balances and transfers.
-
-```tsx
-const SplBalance = ({ mint }) => {
-    const { balance, send, isSending } = useSplToken(mint);
-
-    return (
-        <div>
-            <p>Amount: {balance?.uiAmount ?? '0'}</p>
-            <button
-                disabled={isSending}
-                onClick={() =>
-                    send({
-                        amount: 1n,
-                        destinationOwner: 'Destination111111111111111111111111',
-                    })
-                }
-            >
-                Send 1 token
-            </button>
-        </div>
-    );
-};
-```
-
-### Transaction pool
-
-Compose instructions, refresh blockhashes automatically, and send transactions from one hook.
-
-```tsx
-import type { TransactionInstructionInput } from '@solana/client';
-
-const useMemoizedInstruction = (): TransactionInstructionInput => ({
-    accounts: [],
-    data: new Uint8Array(),
-    programAddress: 'Example1111111111111111111111111111111111',
-});
-
-const TransactionFlow = () => {
-    const instruction = useMemoizedInstruction();
-    const {
-        addInstruction,
-        prepareAndSend,
-        sendStatus,
-        latestBlockhash,
-    } = useTransactionPool();
-
-    return (
-        <div>
-            <button onClick={() => addInstruction(instruction)}>Add instruction</button>
-            <button disabled={sendStatus === 'loading'} onClick={() => prepareAndSend()}>
-                {sendStatus === 'loading' ? 'Sending…' : 'Prepare & Send'}
-            </button>
-            <p>Recent blockhash: {latestBlockhash.blockhash ?? 'loading…'}</p>
-        </div>
-    );
-};
-```
-
-### Client store access
-
-Drop down to the underlying Zustand store when you need bespoke selectors.
-
-```tsx
-import { useClientStore } from '@solana/react-hooks';
-
-function ClusterStatus() {
-    const cluster = useClientStore((state) => state.cluster);
-    return <p>Cluster: {cluster.status.status}</p>;
+function SendSol({ destination }: { destination: string }) {
+  const { send, isSending, status, signature, error } = useSolTransfer(); // expects a connected wallet
+  return (
+    <div>
+      <button
+        disabled={isSending}
+        onClick={() =>
+          send({ destination, lamports: 100_000_000n /* 0.1 SOL */ })
+        }
+      >
+        {isSending ? "Sending…" : "Send 0.1 SOL"}
+      </button>
+      <p>Status: {status}</p>
+      {signature ? <p>Signature: {signature}</p> : null}
+      {error ? <p role="alert">Error: {String(error)}</p> : null}
+    </div>
+  );
 }
 ```
 
-### General transaction sender
-
-Use `useSendTransaction` when you already have instructions/messages and just need a mutation helper
-that exposes `{ send, sendPrepared, status, error, signature }`. When no authority is supplied, it
-will use the currently connected wallet session by default.
+### SPL token balance + transfer
 
 ```tsx
-import { useSendTransaction } from '@solana/react-hooks';
+import { useSplToken } from "@solana/react-hooks";
 
-function SendAnythingButton({ instructions }) {
-    const { send, isSending, signature, error } = useSendTransaction();
-
-    return (
-        <div>
-            <button disabled={isSending} onClick={() => send({ instructions })}>
-                {isSending ? 'Submitting…' : 'Send transaction'}
-            </button>
-            {signature ? <p>Signature: {signature}</p> : null}
-            {error ? <p role="alert">Failed to send: {String(error)}</p> : null}
-        </div>
-    );
+function TokenPanel({
+  mint,
+  destinationOwner,
+}: {
+  mint: string;
+  destinationOwner: string;
+}) {
+  const { balance, send, isSending, owner } = useSplToken(mint);
+  return (
+    <div>
+      <p>Owner: {owner ?? "Connect wallet"}</p>
+      <p>Balance: {balance?.uiAmount ?? "0"}</p>
+      <button
+        disabled={isSending || !owner}
+        onClick={() => send({ amount: 1n, destinationOwner })}
+      >
+        {isSending ? "Sending…" : "Send 1 token"}
+      </button>
+    </div>
+  );
 }
 ```
 
-### Signature helpers
-
-Poll RPC for signature metadata or wait for a confirmation level without writing loops.
+### Build and send arbitrary transactions
 
 ```tsx
-import { useSignatureStatus, useWaitForSignature } from '@solana/react-hooks';
+import type { TransactionInstructionInput } from "@solana/client";
+import { useTransactionPool } from "@solana/react-hooks";
 
-function SignatureStatusCard({ signature }) {
-    const status = useSignatureStatus(signature);
-
-    if (status.isLoading) return <p>Loading…</p>;
-    if (status.isError) return <p>RPC error.</p>;
-
-    return (
-        <div>
-            <p>Confirmation: {status.confirmationStatus ?? 'pending'}</p>
-            <button onClick={() => status.refresh()}>Refresh</button>
-        </div>
-    );
-}
-
-function WaitForSignature({ signature }) {
-    const wait = useWaitForSignature(signature, { commitment: 'finalized' });
-
-    if (wait.waitStatus === 'error') return <p role="alert">Failed: {JSON.stringify(wait.waitError)}</p>;
-    if (wait.waitStatus === 'success') return <p>Finalized!</p>;
-    if (wait.waitStatus === 'waiting') return <p>Waiting for confirmation…</p>;
-    return <p>Provide a signature</p>;
+function TransactionFlow({ ix }: { ix: TransactionInstructionInput }) {
+  const pool = useTransactionPool();
+  return (
+    <div>
+      <button onClick={() => pool.addInstruction(ix)}>Add instruction</button>
+      <button disabled={pool.isSending} onClick={() => pool.prepareAndSend()}>
+        {pool.isSending ? "Sending…" : "Prepare & Send"}
+      </button>
+      <p>Blockhash: {pool.latestBlockhash.blockhash ?? "loading…"}</p>
+    </div>
+  );
 }
 ```
 
-## Query hooks
-
-Wrap a subtree with `<SolanaQueryProvider>` and call hooks like `useLatestBlockhash`,
-`useProgramAccounts`, `useSignatureStatus`, or `useSimulateTransaction`. Every hook returns
-`{ data, status, refresh }` so you can read the current value and trigger a refetch. Want to lean on React
-Suspense later? Pass `suspense` to `SolanaQueryProvider` and wrap just the section that should pause in a
-local `<Suspense>` boundary—no hook changes required:
-
-The query provider ships SWR v2-aligned defaults: `revalidateOnFocus`/`revalidateOnReconnect`/`revalidateIfStale`
-are `true`, `dedupingInterval` is `2000`, and `focusThrottleInterval` is `5000`. Override them per-provider via the
-`query.config` prop or per-hook via the `swr` option.
+### Simple mutation helper (when you already have instructions)
 
 ```tsx
-import { SolanaQueryProvider, useBalance } from '@solana/react-hooks';
-import { Suspense } from 'react';
+import { useSendTransaction } from "@solana/react-hooks";
+
+function SendPrepared({ instructions }) {
+  const { send, isSending, signature, error } = useSendTransaction();
+  return (
+    <div>
+      <button disabled={isSending} onClick={() => send({ instructions })}>
+        {isSending ? "Submitting…" : "Send transaction"}
+      </button>
+      {signature ? <p>Signature: {signature}</p> : null}
+      {error ? <p role="alert">{String(error)}</p> : null}
+    </div>
+  );
+}
+```
+
+### Track confirmations for a signature
+
+```tsx
+import { useWaitForSignature } from "@solana/react-hooks";
+
+function SignatureWatcher({ signature }: { signature: string }) {
+  const wait = useWaitForSignature(signature, { commitment: "finalized" });
+  if (wait.waitStatus === "error") return <p role="alert">Failed</p>;
+  if (wait.waitStatus === "success") return <p>Finalized ✅</p>;
+  if (wait.waitStatus === "waiting") return <p>Waiting…</p>;
+  return <p>Provide a signature</p>;
+}
+```
+
+### Query program accounts
+
+```tsx
+import { SolanaQueryProvider, useProgramAccounts } from "@solana/react-hooks";
+
+function ProgramAccounts({ program }: { program: string }) {
+  const query = useProgramAccounts(program);
+  if (query.isLoading) return <p>Loading…</p>;
+  if (query.isError) return <p role="alert">RPC error</p>;
+  return (
+    <div>
+      <button onClick={() => query.refresh()}>Refresh</button>
+      <ul>
+        {query.accounts.map(({ pubkey }) => (
+          <li key={pubkey.toString()}>{pubkey.toString()}</li>
+        ))}
+      </ul>
+    </div>
+  );
+}
+
+function ProgramAccountsSection({ program }: { program: string }) {
+  return (
+    <SolanaQueryProvider>
+      <ProgramAccounts program={program} />
+    </SolanaQueryProvider>
+  );
+}
+```
+
+### Simulate a transaction
+
+```tsx
+import { useSimulateTransaction } from "@solana/react-hooks";
+
+function Simulation({ wire }: { wire: string }) {
+  const sim = useSimulateTransaction(wire);
+  if (sim.isLoading) return <p>Simulating…</p>;
+  if (sim.isError) return <p role="alert">Simulation failed</p>;
+  return (
+    <div>
+      <button onClick={() => sim.refresh()}>Re-run</button>
+      <pre>{JSON.stringify(sim.logs, null, 2)}</pre>
+    </div>
+  );
+}
+```
+
+## Using Suspense (opt-in)
+
+Enable Suspense per subtree by setting `suspense` on `SolanaQueryProvider` and wrapping content in a React `<Suspense>` boundary. This keeps the rest of the UI non-blocking.
+
+```tsx
+import { SolanaQueryProvider, useBalance } from "@solana/react-hooks";
+import { Suspense } from "react";
 
 function BalanceDetails({ address }: { address: string }) {
-    const balance = useBalance(address);
-    return <p>Lamports: {balance.lamports?.toString() ?? '0'}</p>;
+  const balance = useBalance(address);
+  return <p>Lamports: {balance.lamports?.toString() ?? "0"}</p>;
 }
 
 export function WalletPanel({ address }: { address: string }) {
-    return (
-        <SolanaQueryProvider suspense>
-            {/* Only this block suspends while balance loads */}
-            <Suspense fallback={<p>Loading balance…</p>}>
-                <BalanceDetails address={address} />
-            </Suspense>
-        </SolanaQueryProvider>
-    );
+  return (
+    <SolanaQueryProvider suspense>
+      <Suspense fallback={<p>Loading balance…</p>}>
+        <BalanceDetails address={address} />
+      </Suspense>
+    </SolanaQueryProvider>
+  );
 }
 ```
 
-### Latest blockhash
-
-Poll or refetch the cluster's latest blockhash.
+## Provider SWR config (optional)
 
 ```tsx
-import { SolanaQueryProvider, useLatestBlockhash } from '@solana/react-hooks';
-
-function BlockhashTicker() {
-    const latest = useLatestBlockhash({ swr: { refreshInterval: 20_000 } });
-    if (latest.status === 'loading') return <p>Fetching blockhash…</p>;
-    if (latest.status === 'error') return <p role="alert">Failed to fetch blockhash.</p>;
-
-    return (
-        <div>
-            <button onClick={() => latest.refresh()}>Refresh</button>
-            <p>Status: {latest.status}</p>
-            <p>Blockhash: {latest.blockhash ?? 'unknown'}</p>
-        </div>
-    );
-}
-
-export function BlockhashCard() {
-    return (
-        <SolanaQueryProvider>
-            <BlockhashTicker />
-        </SolanaQueryProvider>
-    );
+export function App() {
+  return (
+    <SolanaProvider
+      client={client}
+      query={{
+        config: {
+          revalidateOnFocus: false,
+          revalidateOnReconnect: false,
+          refreshInterval: 30_000,
+        },
+      }}
+    >
+      <WalletPanel />
+    </SolanaProvider>
+  );
 }
 ```
 
-### Program accounts
+Defaults when you omit `query.config`:
+- `revalidateOnFocus` / `revalidateOnReconnect` / `revalidateIfStale`: `true`
+- `dedupingInterval`: `2000ms`
+- `focusThrottleInterval`: `5000ms`
+
+SWR background: stale-while-revalidate (RFC 5861): https://datatracker.ietf.org/doc/html/rfc5861
+
+### Work with the client store directly
 
 ```tsx
-import { autoDiscover, backpack, createClient, phantom, solflare } from '@solana/client';
-import { SolanaProvider, SolanaQueryProvider, useProgramAccounts } from '@solana/react-hooks';
+import { useClientStore } from "@solana/react-hooks";
 
-const walletConnectors = [...phantom(), ...solflare(), ...backpack(), ...autoDiscover()];
-const client = createClient({
-    endpoint: 'https://api.devnet.solana.com',
-    websocketEndpoint: 'wss://api.devnet.solana.com',
-    walletConnectors,
-});
-
-function ProgramAccountsList({ programAddress }) {
-    const query = useProgramAccounts(programAddress);
-    if (query.status === 'loading') return <p>Loading accounts…</p>;
-    if (query.status === 'error') return <p role="alert">Retry later.</p>;
-
-    return (
-        <div>
-            <button onClick={() => query.refresh()}>Refresh</button>
-            <p>Status: {query.status}</p>
-            <ul>
-                {query.accounts?.map(({ pubkey }) => (
-                    <li key={pubkey.toString()}>{pubkey.toString()}</li>
-                ))}
-            </ul>
-        </div>
-    );
-}
-
-export function QueryDemo({ programAddress }) {
-    return (
-        <SolanaProvider client={client}>
-            <SolanaQueryProvider>
-                <ProgramAccountsList programAddress={programAddress} />
-            </SolanaQueryProvider>
-        </SolanaProvider>
-    );
+function ClusterBadge() {
+  const cluster = useClientStore((s) => s.cluster);
+  return <p>Endpoint: {cluster.endpoint}</p>;
 }
 ```
 
-### Transaction simulation
+## Notes and defaults
 
-Simulate any transaction payload (wire string or object) and read RPC logs.
+- Wallet connectors: use `autoDiscover()` to pick up Wallet Standard injectables; or explicitly compose `phantom()`, `solflare()`, `backpack()`, etc.
+- Queries: all RPC query hooks accept `swr` options under `swr` and `disabled` flags. Suspense is opt-in via `SolanaQueryProvider`’s `suspense` prop.
+- Authorities: transaction helpers default to the connected wallet session when `authority` is omitted.
+- Types: every hook exports `UseHookNameParameters` / `UseHookNameReturnType` aliases.
 
-```tsx
-import { useSimulateTransaction } from '@solana/react-hooks';
+## More resources
 
-function SimulationLogs({ transaction }) {
-    const query = useSimulateTransaction(transaction);
-    if (query.status === 'loading') return <p>Simulating…</p>;
-    if (query.status === 'error') return <p role="alert">Simulation failed.</p>;
-    return (
-        <div>
-            <button onClick={() => query.refresh()}>Re-run</button>
-            <p>Status: {query.status}</p>
-            <pre>{JSON.stringify(query.logs, null, 2)}</pre>
-        </div>
-    );
-}
-```
-
-## Going further
-
-- Wallet connection UI: `useWalletConnection` gives you the current wallet, connect/disconnect
-  helpers, and the connector list from `client.connectors` (or an explicit override). Pair it with
-  your preferred UI, or `WalletConnectionManager` for a simple modal state helper.
-- Signing helpers: the wallet session returned by `useWallet` exposes `signMessage`,
-  `signTransaction`, and `sendTransaction` when supported by the connector. These connector methods
-  replace the deprecated Wallet Standard shims.
-- Query hooks keep SWR options under `swr` for consistency (for example,
-  `useProgramAccounts(address, { swr: { revalidateOnFocus: false } })`) and expose typed parameter
-  and return aliases across all hooks.
-- Type helpers: use `UseHookNameParameters` / `UseHookNameReturnType` for public hooks.
-- Looking for examples? See `examples/vite-react` for a ready-to-run, tabbed playground that wires
-  the provider, hooks, and mock UIs together across wallet/state, transaction, and query demos.
-
-## Scripts
-
-- `pnpm build` – run both JS compilation and type definition emit
-- `pnpm test:typecheck` – strict type-checking without emit
-- `pnpm lint` / `pnpm format` – Biome-powered linting and formatting
+- Playground: `examples/vite-react` (run with `pnpm install && pnpm dev`).
+- Next.js reference app: `examples/nextjs`.
+- Hook JSDoc lives in `src/hooks.ts`, `src/queryHooks.ts`, `src/ui.tsx`.

--- a/packages/react-hooks/src/hooks.ts
+++ b/packages/react-hooks/src/hooks.ts
@@ -141,6 +141,12 @@ function useSuspenseFetcher(
 
 /**
  * Read the full cluster state managed by the client store.
+ *
+ * @example
+ * ```ts
+ * const cluster = useClusterState();
+ * console.log(cluster.endpoint, cluster.status);
+ * ```
  */
 export function useClusterState(): ClusterState {
 	const selector = useMemo(createClusterSelector, []);
@@ -148,7 +154,13 @@ export function useClusterState(): ClusterState {
 }
 
 /**
- * Read the current cluster connection status.
+ * Read just the cluster connection status slice (connecting/ready/error).
+ *
+ * @example
+ * ```ts
+ * const status = useClusterStatus();
+ * if (status.status === 'error') console.error(status.error);
+ * ```
  */
 export function useClusterStatus(): ClusterStatus {
 	const selector = useMemo(createClusterStatusSelector, []);
@@ -156,7 +168,15 @@ export function useClusterStatus(): ClusterStatus {
 }
 
 /**
- * Access the wallet status tracked by the client store.
+ * Access the wallet status tracked by the client store (connected/connecting/error/disconnected).
+ *
+ * @example
+ * ```ts
+ * const wallet = useWallet();
+ * if (wallet.status === 'connected') {
+ *   console.log(wallet.session.account.address.toString());
+ * }
+ * ```
  */
 export function useWallet(): WalletStatus {
 	const selector = useMemo(createWalletSelector, []);
@@ -164,7 +184,13 @@ export function useWallet(): WalletStatus {
 }
 
 /**
- * Convenience helper that returns the active wallet session when connected.
+ * Convenience helper that returns the active wallet session when connected, otherwise `undefined`.
+ *
+ * @example
+ * ```ts
+ * const session = useWalletSession();
+ * const address = session?.account.address.toString();
+ * ```
  */
 export function useWalletSession(): WalletSession | undefined {
 	const wallet = useWallet();
@@ -175,7 +201,13 @@ export function useWalletSession(): WalletSession | undefined {
 }
 
 /**
- * Access the headless client actions.
+ * Access the headless client actions (setCluster, fetchAccount, connectWallet, etc.).
+ *
+ * @example
+ * ```ts
+ * const actions = useWalletActions();
+ * await actions.connectWallet('phantom');
+ * ```
  */
 export function useWalletActions() {
 	const client = useSolanaClient();
@@ -184,6 +216,12 @@ export function useWalletActions() {
 
 /**
  * Stable connect helper that resolves to {@link ClientActions.connectWallet}.
+ *
+ * @example
+ * ```ts
+ * const connect = useConnectWallet();
+ * await connect('phantom', { autoConnect: true });
+ * ```
  */
 export function useConnectWallet(): (
 	connectorId: string,
@@ -199,6 +237,12 @@ export function useConnectWallet(): (
 
 /**
  * Stable disconnect helper mapping to {@link ClientActions.disconnectWallet}.
+ *
+ * @example
+ * ```ts
+ * const disconnect = useDisconnectWallet();
+ * await disconnect();
+ * ```
  */
 export function useDisconnectWallet(): () => Promise<void> {
 	const client = useSolanaClient();
@@ -209,6 +253,13 @@ type SolTransferSignature = UnwrapPromise<ReturnType<SolTransferHelper['sendTran
 
 /**
  * Convenience wrapper around the SOL transfer helper that tracks status and signature.
+ *
+ * @example
+ * ```ts
+ * const { send, signature, status } = useSolTransfer();
+ * await send({ amount: 1_000_000n, destination: toAddress('...') });
+ * console.log(signature, status);
+ * ```
  */
 export function useSolTransfer(): Readonly<{
 	error: unknown;
@@ -274,6 +325,14 @@ type UseSplTokenOptions = Readonly<{
 
 /**
  * Simplified SPL token hook that scopes helpers by mint and manages balance state.
+ *
+ * @example
+ * ```ts
+ * const { balance, send, owner } = useSplToken(mintAddress);
+ * if (owner && balance?.exists) {
+ *   await send({ amount: 1n, destinationOwner: toAddress('...') });
+ * }
+ * ```
  */
 export function useSplToken(
 	mint: AddressLike,
@@ -409,6 +468,12 @@ export function useSplToken(
 
 /**
  * Subscribe to the account cache for a given address, optionally triggering fetch & watch helpers.
+ *
+ * @example
+ * ```ts
+ * const account = useAccount(pubkey, { watch: true });
+ * const lamports = account?.lamports ?? null;
+ * ```
  */
 export function useAccount(addressLike?: AddressLike, options: UseAccountOptions = {}): AccountCacheEntry | undefined {
 	const client = useSolanaClient();
@@ -456,7 +521,12 @@ export function useAccount(addressLike?: AddressLike, options: UseAccountOptions
 }
 
 /**
- * Tracks a lamport balance for the provided address. Fetches immediately and watches by default.
+ * Track lamport balance for an address. Fetches immediately and watches by default.
+ *
+ * @example
+ * ```ts
+ * const { lamports, fetching } = useBalance(pubkey);
+ * ```
  */
 export function useBalance(
 	addressLike?: AddressLike,
@@ -551,7 +621,15 @@ type UseTransactionPoolPrepareAndSendOptions = TransactionPoolPrepareAndSendOpti
 type TransactionSignature = Signature;
 
 /**
- * Manage a mutable set of instructions and use the transaction helper to prepare and send transactions.
+ * Manage a mutable set of instructions and use the transaction helper to prepare/sign/send.
+ *
+ * @example
+ * ```ts
+ * const pool = useTransactionPool();
+ * pool.addInstruction(ix);
+ * const prepared = await pool.prepare({ feePayer });
+ * await pool.send();
+ * ```
  */
 export function useTransactionPool(config: UseTransactionPoolConfig = {}): Readonly<{
 	addInstruction(instruction: TransactionInstructionInput): void;
@@ -677,6 +755,12 @@ type UseSendTransactionResult = Readonly<{
 
 /**
  * General-purpose helper that prepares and sends arbitrary transactions through {@link TransactionHelper}.
+ *
+ * @example
+ * ```ts
+ * const { send, status } = useSendTransaction();
+ * await send({ instructions: [ix], feePayer });
+ * ```
  */
 export function useSendTransaction(): UseSendTransactionResult {
 	const client = useSolanaClient();
@@ -762,6 +846,11 @@ type SignatureStatusState = SolanaQueryResult<SignatureStatusValue | null> &
 
 /**
  * Fetch the RPC status for a transaction signature.
+ *
+ * @example
+ * ```ts
+ * const { signatureStatus, confirmationStatus } = useSignatureStatus(sig);
+ * ```
  */
 export function useSignatureStatus(
 	signatureInput?: SignatureLike,
@@ -822,7 +911,12 @@ type WaitForSignatureState = SignatureStatusState &
 	}>;
 
 /**
- * Polls signature status data until the desired commitment (or subscription notification) is reached.
+ * Poll signature status until the desired commitment (or subscription notification) is reached.
+ *
+ * @example
+ * ```ts
+ * const { waitStatus, confirmationStatus } = useWaitForSignature(sig, { commitment: 'finalized' });
+ * ```
  */
 export function useWaitForSignature(
 	signatureInput?: SignatureLike,

--- a/packages/react-hooks/src/query.ts
+++ b/packages/react-hooks/src/query.ts
@@ -28,6 +28,23 @@ export type SolanaQueryResult<Data> = Readonly<{
 	status: QueryStatus;
 }>;
 
+/**
+ * Low-level RPC query helper that scopes SWR keys to the active cluster and exposes a Solana-friendly
+ * status shape. Prefer this when you need custom fetch logic beyond the built-in hooks.
+ *
+ * @param scope - Namespace label for the query key (for debugging and cache clarity).
+ * @param args - Additional key params that uniquely identify the query (e.g. signature, address).
+ * @param fetcher - Async function that receives the current {@link SolanaClient} and returns data.
+ * @param options - Optional flags to disable the query or pass through SWR configuration.
+ * @example
+ * ```ts
+ * const slotQuery = useSolanaRpcQuery(
+ *   'slot',
+ *   ['slot'],
+ *   (client) => client.runtime.rpc.getLatestBlockhash().send().then((r) => r.context.slot),
+ * );
+ * ```
+ */
 export function useSolanaRpcQuery<Data>(
 	scope: string,
 	args: readonly unknown[],

--- a/packages/react-hooks/src/queryHooks.ts
+++ b/packages/react-hooks/src/queryHooks.ts
@@ -42,6 +42,15 @@ export type UseLatestBlockhashReturnType = SolanaQueryResult<LatestBlockhashResp
 		lastValidBlockHeight: bigint | null;
 	}>;
 
+/**
+ * Fetch the current cluster blockhash and keep it warm with a configurable polling interval.
+ * Falls back to the client's active commitment when one is not provided.
+ *
+ * @example
+ * ```ts
+ * const { blockhash, lastValidBlockHeight } = useLatestBlockhash({ refreshInterval: 10_000 });
+ * ```
+ */
 export function useLatestBlockhash(options: UseLatestBlockhashParameters = {}): UseLatestBlockhashReturnType {
 	const {
 		commitment,
@@ -94,6 +103,15 @@ export type UseProgramAccountsReturnType = SolanaQueryResult<ProgramAccountsResp
 		accounts: ProgramAccountsResponse;
 	}>;
 
+/**
+ * Fetch accounts owned by a program, keyed by the program address. The query is disabled until a
+ * program address is provided, and respects both explicit and client default commitments.
+ *
+ * @example
+ * ```ts
+ * const programAccounts = useProgramAccounts(programId, { config: { dataSlice: { offset: 0, length: 0 } } });
+ * ```
+ */
 export function useProgramAccounts(
 	programAddress?: AddressLike,
 	options?: UseProgramAccountsParameters,
@@ -147,6 +165,16 @@ export type UseSimulateTransactionReturnType = SolanaQueryResult<SimulateTransac
 		logs: readonly string[];
 	}>;
 
+/**
+ * Simulate a transaction or wire payload and return simulation logs/results. Disabled until a
+ * transaction payload is provided; uses client commitment when not specified in options.
+ *
+ * @example
+ * ```ts
+ * const simulation = useSimulateTransaction(base64Wire, { refreshInterval: 0 });
+ * console.log(simulation.logs);
+ * ```
+ */
 export function useSimulateTransaction(
 	transaction?: SimulationInput | null,
 	options?: UseSimulateTransactionParameters,

--- a/packages/react-hooks/src/useClientStore.ts
+++ b/packages/react-hooks/src/useClientStore.ts
@@ -16,6 +16,10 @@ export function useClientStore<T>(selector: UseClientStoreSelector<T>): T;
  *
  * @param selector - Derives the slice of state to observe. Defaults to the entire state.
  * @returns Selected state slice that triggers re-render when it changes.
+ * @example
+ * ```ts
+ * const commitment = useClientStore((state) => state.cluster.commitment);
+ * ```
  */
 export function useClientStore<T>(selector?: UseClientStoreSelector<T>): ClientState | T {
 	const client = useSolanaClient();


### PR DESCRIPTION
## Summary
- add comprehensive JSDoc and README examples for react-hooks, keeping connection boilerplate minimal and pushing SWR config lower in the doc
- add hydration guard to  to avoid SSR mismatches when connectors differ between server/client
- document client actions and add changeset for next RC

## Testing
- n/a (docs + non-runtime hydration guard)