### PR TITLE
Fix publish workflow husky block

### DIFF
--- a/.changeset/pre.json
+++ b/.changeset/pre.json
@@ -1,16 +1,14 @@
 {
-  "mode": "pre",
-  "tag": "rc",
-  "initialVersions": {
-    "@solana/example-nextjs": "0.0.0",
-    "@solana/example-vite-react": "0.0.11",
-    "@solana/client": "0.2.2",
-    "@solana/react-hooks": "0.5.0",
-    "@solana/web3-compat": "0.0.5",
-    "@solana/test-types-smoke": "0.0.10",
-    "@solana/web3-compat-parity-tests": "0.0.0"
-  },
-  "changesets": [
-    "rc-1-bump"
-  ]
+	"mode": "pre",
+	"tag": "rc",
+	"initialVersions": {
+		"@solana/example-nextjs": "0.0.0",
+		"@solana/example-vite-react": "0.0.11",
+		"@solana/client": "0.2.2",
+		"@solana/react-hooks": "0.5.0",
+		"@solana/web3-compat": "0.0.5",
+		"@solana/test-types-smoke": "0.0.10",
+		"@solana/web3-compat-parity-tests": "0.0.0"
+	},
+	"changesets": ["rc-1-bump", "rc-2-docs-and-hydration"]
 }

--- a/.github/workflows/publish-packages.yml
+++ b/.github/workflows/publish-packages.yml
@@ -52,6 +52,7 @@ jobs:
         with:
           createGithubReleases: true
         env:
+          HUSKY: '0'
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Choose final step


### PR DESCRIPTION
## Summary
- add missing changeset entry to pre.json so RC versions include recent changes
- set HUSKY=0 for changesets/action in publish workflow to avoid pre-commit formatter blocking automated version commits

## Testing
- n/a (workflow/config only)