### PR TITLE
Fix autoConnect persistence and update example

### DIFF
--- a/.changeset/rc-4-autoconnect.md
+++ b/.changeset/rc-4-autoconnect.md
@@ -1,0 +1,5 @@
+---
+'@solana/react-hooks': patch
+---
+
+Honor per-connection `autoConnect` preference even when provider auto-connect is disabled, and update the example app to opt out at the provider level while passing `autoConnect: true` from the handlers.

--- a/examples/vite-react/src/App.tsx
+++ b/examples/vite-react/src/App.tsx
@@ -18,7 +18,6 @@ import { TransactionPoolPanel } from './components/TransactionPoolPanel.tsx';
 import { Tabs, TabsContent, TabsList, TabsTrigger } from './components/ui/tabs.tsx';
 import { WalletControls } from './components/WalletControls.tsx';
 
-const LAST_CONNECTOR_STORAGE_KEY = 'solana:last-connector';
 const walletConnectors = [...phantom(), ...solflare(), ...backpack(), ...autoDiscover()];
 const client = createClient({
 	commitment: 'confirmed',
@@ -29,11 +28,7 @@ const client = createClient({
 
 export default function App() {
 	return (
-		<SolanaProvider
-			client={client}
-			query={{ suspense: true }}
-			walletPersistence={{ storageKey: LAST_CONNECTOR_STORAGE_KEY }}
-		>
+		<SolanaProvider client={client} query={{ suspense: true }}>
 			<DemoApp />
 		</SolanaProvider>
 	);

--- a/examples/vite-react/src/components/WalletControls.tsx
+++ b/examples/vite-react/src/components/WalletControls.tsx
@@ -20,7 +20,7 @@ export function WalletControls() {
 	const handleConnect = useCallback(
 		async (connectorId: string) => {
 			try {
-				await connect(connectorId);
+				await connect(connectorId, { autoConnect: true });
 			} catch {
 				// Store will expose the error state; nothing else to do here.
 			}

--- a/packages/react-hooks/src/SolanaProvider.tsx
+++ b/packages/react-hooks/src/SolanaProvider.tsx
@@ -169,16 +169,18 @@ function WalletPersistence({
 	}, [initialState, legacyConnectorId]);
 
 	useEffect(() => {
-		if (!autoConnect || hasAttemptedAutoConnect) {
+		const persisted = persistedStateRef.current ?? initialState;
+		const persistedAutoConnect = persisted?.autoconnect ?? false;
+		const autoConnectEnabled = persistedAutoConnect || autoConnect;
+		if (!autoConnectEnabled || hasAttemptedAutoConnect) {
 			return;
 		}
 		if (wallet.status === 'connected' || wallet.status === 'connecting') {
 			setHasAttemptedAutoConnect(true);
 			return;
 		}
-		const state = persistedStateRef.current ?? initialState;
-		const connectorId = state?.lastConnectorId ?? legacyConnectorIdRef.current;
-		const shouldAutoConnect = (state?.autoconnect ?? autoConnect) && connectorId;
+		const connectorId = persisted?.lastConnectorId ?? legacyConnectorIdRef.current;
+		const shouldAutoConnect = autoConnectEnabled && connectorId;
 		if (!shouldAutoConnect || !connectorId) return;
 		const connector = client.connectors.get(connectorId);
 		if (!connector) return;


### PR DESCRIPTION
## Summary
- honor persisted per-connection  preference even when provider autoConnect is false
- update Vite React example to disable provider auto-connect and pass  from wallet controls
- add changeset to include this in next RC

## Testing
- pnpm vitest packages/react-hooks/src/SolanaProvider.test.tsx
- pnpm --filter @solana/example-vite-react dev (manual verification)