### PR TITLE
feat: document cluster monikers and update examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ Framework for Solana dApps: evolving multi-framework client core (React-first to
 
 ## Packages
 
-- [`@solana/client`](packages/client/README.md) – headless Solana client with transaction helpers and wallet orchestration.
+- [`@solana/client`](packages/client/README.md) – headless Solana client with transaction helpers, moniker-based endpoint helpers, and wallet orchestration.
 - [`@solana/react-hooks`](packages/react-hooks/README.md) – React bindings, providers, and UI helpers powered by the client.
   
 ## Example

--- a/examples/nextjs/README.md
+++ b/examples/nextjs/README.md
@@ -14,14 +14,10 @@ pnpm --filter @solana/example-nextjs dev
 
 Open http://localhost:3000 and pick a wallet. The app runs against Devnet by default.
 
-## Configuration
-
-- `NEXT_PUBLIC_SOLANA_RPC` – RPC endpoint (default: `https://api.devnet.solana.com`)
-- `NEXT_PUBLIC_SOLANA_WS` – WebSocket endpoint (default inferred from RPC)
-
 `next.config.mjs` enables `transpilePackages` for the `@solana/*` packages so the hooks work with the
 Next.js bundler. Tailwind CSS v4 is declared inside `app/globals.css` with `@import "tailwindcss";`
-and `@source "./app/**/*.{ts,tsx}"` for class detection.
+and `@source "./app/**/*.{ts,tsx}"` for class detection. The Solana client uses the `cluster` moniker
+(`devnet`) set in `app/providers.tsx`; change it there to target another cluster.
 
 ## Other scripts
 

--- a/examples/nextjs/app/providers.tsx
+++ b/examples/nextjs/app/providers.tsx
@@ -6,8 +6,6 @@ import type { PropsWithChildren } from 'react';
 
 const defaultConfig: SolanaClientConfig = {
 	cluster: 'devnet',
-	rpc: 'https://api.devnet.solana.com',
-	websocket: 'wss://api.devnet.solana.com',
 };
 
 function Providers({ children }: PropsWithChildren) {

--- a/examples/vite-react/README.md
+++ b/examples/vite-react/README.md
@@ -7,7 +7,7 @@ The example mirrors the vanilla proof-of-concept by wiring wallet discovery, SOL
 All hooks expose `UseHookNameParameters` / `UseHookNameReturnType` aliases so you can type your own helpers consistently with the library.
 
 The app starts with connector-first setup: build connectors, create a client, and pass it to the provider (which
-includes the query layer).
+includes the query layer). Cluster URLs are resolved from the `cluster` moniker (Devnet here).
 
 ```tsx
 import { autoDiscover, backpack, createClient, phantom, solflare } from '@solana/client';
@@ -15,8 +15,7 @@ import { SolanaProvider } from '@solana/react-hooks';
 
 const walletConnectors = [...phantom(), ...solflare(), ...backpack(), ...autoDiscover()];
 const client = createClient({
-	endpoint: 'https://api.devnet.solana.com',
-	websocketEndpoint: 'wss://api.devnet.solana.com',
+	cluster: 'devnet',
 	walletConnectors,
 });
 

--- a/examples/vite-react/src/App.tsx
+++ b/examples/vite-react/src/App.tsx
@@ -22,8 +22,7 @@ import { WalletControls } from './components/WalletControls.tsx';
 const walletConnectors = [...phantom(), ...solflare(), ...backpack(), ...autoDiscover()];
 const client = createClient({
 	commitment: 'confirmed',
-	endpoint: 'https://api.devnet.solana.com',
-	websocketEndpoint: 'wss://api.devnet.solana.com',
+	cluster: 'devnet',
 	walletConnectors,
 });
 

--- a/packages/client/README.md
+++ b/packages/client/README.md
@@ -177,6 +177,48 @@ const watcher = client.watchers.watchSignature(
 watcher.abort();
 ```
 
+## Cluster monikers and endpoints
+
+Pass a cluster moniker to auto-resolve RPC + WebSocket URLs. Monikers map to:
+
+- `mainnet` / `mainnet-beta` → `https://api.mainnet-beta.solana.com`
+- `testnet` → `https://api.testnet.solana.com`
+- `devnet` (default) → `https://api.devnet.solana.com`
+- `localnet` / `localhost` → `http://127.0.0.1:8899`
+
+WebSocket URLs are inferred (`wss://` or `ws://`) when not supplied. Override with `endpoint`/`rpc` or `websocket`/`websocketEndpoint` when you need a custom host.
+
+```ts
+import { autoDiscover, createClient } from "@solana/client";
+
+const client = createClient({
+  cluster: "mainnet", // or 'devnet' | 'testnet' | 'localnet' | 'localhost'
+  walletConnectors: autoDiscover(),
+});
+```
+
+Custom endpoint with inferred WebSocket:
+
+```ts
+const client = createClient({
+  endpoint: "http://127.0.0.1:8899", // websocket inferred as ws://127.0.0.1:8900
+});
+```
+
+Use `resolveCluster` directly when you need the resolved URLs without creating a client:
+
+```ts
+import { resolveCluster } from "@solana/client";
+
+const resolved = resolveCluster({ moniker: "testnet" });
+console.log(resolved.endpoint, resolved.websocketEndpoint);
+```
+
+Notes:
+
+- Default moniker is `devnet` when nothing is provided; moniker becomes `custom` when you pass a raw `endpoint`.
+- `createClient`, `createDefaultClient` (`resolveClientConfig`), and `SolanaProvider` all use `resolveCluster` under the hood, so the moniker/endpoint behavior is consistent across entrypoints.
+
 ## Notes and defaults
 
 - Wallet connectors: `autoDiscover()` picks up Wallet Standard injectables; compose `phantom()`, `solflare()`, `backpack()`, or `injected()` when you need explicit control.


### PR DESCRIPTION
Closes https://github.com/solana-foundation/framework-kit/issues/70

## Summary
- Documented cluster moniker helpers in `@solana/client` README with the moniker -> endpoint map, websocket inference notes, and resolveCluster usage.
- Updated example apps (Vite React and Next.js) and their READMEs to rely on moniker-based configuration (cluster: 'devnet') instead of hardcoded RPC/WebSocket URLs.
- Added a brief note in the root README highlighting moniker-based endpoint helpers in `@solana/client`.


## Testing
- [x] `pnpm lint`
- [x] `pnpm test`
- [x] `pnpm build`
- [ ] Other (describe):
