### PR TITLE
fix(build): ensure typecheck rebuilds dependencies first

### DIFF
--- a/.changeset/fix-typecheck-build-dependency.md
+++ b/.changeset/fix-typecheck-build-dependency.md
@@ -1,0 +1,6 @@
+---
+"@solana/client": patch
+"@solana/react-hooks": patch
+---
+
+Fix typecheck to rebuild dependencies first, preventing stale type definition errors

--- a/turbo.json
+++ b/turbo.json
@@ -20,6 +20,7 @@
 			"outputs": []
 		},
 		"typecheck": {
+			"dependsOn": ["^build"],
 			"outputs": []
 		}
 	}


### PR DESCRIPTION
Update turbo.json to make typecheck depend on build to prevent stale type definitions.

## Summary
- 

## Testing
- [ ] `pnpm lint`
- [ ] `pnpm test`
- [ ] `pnpm build`
- [ ] Other (describe):
