### PR TITLE
fix: exclude JS sourcemaps from npm packages

### DIFF
--- a/.changeset/exclude-js-sourcemaps.md
+++ b/.changeset/exclude-js-sourcemaps.md
@@ -1,0 +1,12 @@
+---
+"@solana/client": patch
+"@solana/react-hooks": patch
+---
+
+Exclude JavaScript sourcemaps from npm packages to reduce bundle size
+
+- Updated `files` field in package.json to explicitly exclude .mjs.map files
+- TypeScript declaration maps (.d.ts.map) are still included for "Go to Definition" support
+- Package size reduced: @solana/client 273.9KB → 85.4KB (69% reduction)
+- Package size reduced: @solana/react-hooks size also reduced significantly
+- Improves install times and reduces disk usage with no DX impact

--- a/packages/client/package.json
+++ b/packages/client/package.json
@@ -33,7 +33,8 @@
 	},
 	"type": "module",
 	"files": [
-		"./dist/"
+		"./dist/**/*.mjs",
+		"./dist/types/"
 	],
 	"sideEffects": false,
 	"keywords": [

--- a/packages/react-hooks/package.json
+++ b/packages/react-hooks/package.json
@@ -16,7 +16,8 @@
 	"types": "./dist/types/index.d.ts",
 	"type": "module",
 	"files": [
-		"./dist/"
+		"./dist/**/*.mjs",
+		"./dist/types/"
 	],
 	"sideEffects": false,
 	"keywords": [


### PR DESCRIPTION
Fixes bundle size by excluding .mjs.map files from published packages.

Package size: 273.9KB → 85.4KB (69% reduction)