### PR TITLE
fix: default useAccount hook to fetch and watch automatically

### DIFF
--- a/.changeset/useaccount-default-options.md
+++ b/.changeset/useaccount-default-options.md
@@ -1,0 +1,5 @@
+---
+"@solana/react-hooks": patch
+---
+
+Fix useAccount hook to default `fetch` and `watch` options to `true`, matching the behavior of useBalance. This ensures account data is fetched and watched automatically without requiring explicit options.


### PR DESCRIPTION
## Summary
- Updates `useAccount` hook to default `fetch` and `watch` options to `true`, matching `useBalance` behavior
- This ensures account data is fetched and watched automatically without requiring explicit options
- Adds test to verify the new default behavior

## Test plan
- [x] Added test for default fetch/watch behavior
- [x] Updated existing test to explicitly disable fetch/watch when testing skip behavior
- [x] All existing tests pass

Closes #112