### PR TITLE
feat: add wrapSol/unwrapSol helpers for wSOL operations

### DIFF
--- a/.changeset/add-wsol-wrap-unwrap-helpers.md
+++ b/.changeset/add-wsol-wrap-unwrap-helpers.md
@@ -1,0 +1,33 @@
+---
+"@solana/client": minor
+"@solana/react-hooks": minor
+---
+
+Add wrapSol/unwrapSol helpers for wSOL operations
+
+Adds helper functions to easily wrap native SOL into Wrapped SOL (wSOL) and unwrap it back:
+
+**@solana/client:**
+- `createWsolHelper(runtime)` - Factory function to create wSOL helpers
+- `WsolHelper.sendWrap({ amount, authority })` - Wrap SOL to wSOL
+- `WsolHelper.sendUnwrap({ authority })` - Unwrap wSOL back to SOL (closes the account)
+- `WsolHelper.fetchWsolBalance(owner)` - Get wSOL balance
+- `WsolHelper.deriveWsolAddress(owner)` - Derive the wSOL ATA address
+- `WRAPPED_SOL_MINT` - The wSOL mint address constant
+- `createWsolController()` - Controller for React integration
+
+**@solana/react-hooks:**
+- `useWrapSol()` - Hook for wrapping/unwrapping SOL with status tracking
+
+Example usage:
+```ts
+// Using the client helper
+const wsol = client.wsol;
+await wsol.sendWrap({ amount: 1_000_000_000n, authority: session });
+await wsol.sendUnwrap({ authority: session });
+
+// Using the React hook
+const { wrap, unwrap, balance, isWrapping, isUnwrapping } = useWrapSol();
+await wrap({ amount: 1_000_000_000n });
+await unwrap({});
+```

--- a/examples/vite-react/src/App.tsx
+++ b/examples/vite-react/src/App.tsx
@@ -18,6 +18,7 @@ import { StoreInspectorCard } from './components/StoreInspectorCard.tsx';
 import { TransactionPoolPanel } from './components/TransactionPoolPanel.tsx';
 import { Tabs, TabsContent, TabsList, TabsTrigger } from './components/ui/tabs.tsx';
 import { WalletControls } from './components/WalletControls.tsx';
+import { WrapSolPanel } from './components/WrapSolPanel.tsx';
 
 const walletConnectors = [...phantom(), ...solflare(), ...backpack(), ...metamask(), ...autoDiscover()];
 const client = createClient({
@@ -82,6 +83,7 @@ function DemoApp() {
 							<div className="grid gap-6 lg:grid-cols-2">
 								<SolTransferForm />
 								<SendTransactionCard />
+								<WrapSolPanel />
 								<SplTokenPanel />
 								<StakePanel />
 								<TransactionPoolPanel />

--- a/examples/vite-react/src/components/WrapSolPanel.tsx
+++ b/examples/vite-react/src/components/WrapSolPanel.tsx
@@ -1,0 +1,223 @@
+import { WRAPPED_SOL_MINT } from '@solana/client';
+import { useWalletSession, useWrapSol } from '@solana/react-hooks';
+import { type FormEvent, useState } from 'react';
+
+import { Button } from './ui/button';
+import { Card, CardContent, CardDescription, CardFooter, CardHeader, CardTitle } from './ui/card';
+import { Input } from './ui/input';
+
+function formatError(error: unknown): string {
+	if (error instanceof Error) {
+		return error.message;
+	}
+	if (typeof error === 'string') {
+		return error;
+	}
+	return JSON.stringify(error);
+}
+
+function formatWsolBalance(balance: { amount: bigint; exists: boolean } | null, owner: string | null): string {
+	if (!owner) {
+		return 'Connect a wallet to see your wSOL balance.';
+	}
+	if (!balance) {
+		return 'Loading balance...';
+	}
+	if (!balance.exists) {
+		return '0 wSOL (no token account)';
+	}
+	const solAmount = Number(balance.amount) / 1_000_000_000;
+	return `${solAmount.toFixed(9)} wSOL (${balance.amount.toString()} lamports)`;
+}
+
+export function WrapSolPanel() {
+	const session = useWalletSession();
+	const [wrapAmount, setWrapAmount] = useState('0.1');
+	const {
+		balance,
+		error,
+		isFetching,
+		isUnwrapping,
+		isWrapping,
+		owner,
+		refresh,
+		refreshing,
+		resetUnwrap,
+		resetWrap,
+		unwrap,
+		unwrapError,
+		unwrapSignature,
+		unwrapStatus,
+		wrap,
+		wrapError,
+		wrapSignature,
+		wrapStatus,
+		status,
+	} = useWrapSol();
+
+	const handleWrap = async (event: FormEvent<HTMLFormElement>) => {
+		event.preventDefault();
+		if (!session) {
+			return;
+		}
+		const amountStr = wrapAmount.trim();
+		if (!amountStr) {
+			return;
+		}
+		const solAmount = parseFloat(amountStr);
+		if (Number.isNaN(solAmount) || solAmount <= 0) {
+			return;
+		}
+		// Convert SOL to lamports
+		const lamports = BigInt(Math.floor(solAmount * 1_000_000_000));
+		await wrap({ amount: lamports });
+		await refresh();
+	};
+
+	const handleUnwrap = async () => {
+		if (!session) {
+			return;
+		}
+		await unwrap({});
+		await refresh();
+	};
+
+	const isWalletConnected = Boolean(owner);
+	const hasWsolBalance = balance?.exists && balance.amount > 0n;
+
+	const getWrapStatus = (): string => {
+		if (!owner) {
+			return 'Connect a wallet to wrap SOL.';
+		}
+		if (isWrapping || wrapStatus === 'loading') {
+			return 'Wrapping SOL...';
+		}
+		if (wrapStatus === 'success' && wrapSignature) {
+			return `Wrap successful! Signature: ${String(wrapSignature)}`;
+		}
+		if (wrapStatus === 'error' && wrapError) {
+			return `Wrap failed: ${formatError(wrapError)}`;
+		}
+		return 'Enter an amount and click Wrap to convert SOL to wSOL.';
+	};
+
+	const getUnwrapStatus = (): string => {
+		if (!owner) {
+			return '';
+		}
+		if (isUnwrapping || unwrapStatus === 'loading') {
+			return 'Unwrapping wSOL...';
+		}
+		if (unwrapStatus === 'success' && unwrapSignature) {
+			return `Unwrap successful! Signature: ${String(unwrapSignature)}`;
+		}
+		if (unwrapStatus === 'error' && unwrapError) {
+			return `Unwrap failed: ${formatError(unwrapError)}`;
+		}
+		if (!hasWsolBalance) {
+			return 'No wSOL to unwrap.';
+		}
+		return 'Click Unwrap to convert all wSOL back to SOL.';
+	};
+
+	return (
+		<Card aria-disabled={!isWalletConnected}>
+			<CardHeader>
+				<div className="space-y-1.5">
+					<CardTitle>Wrapped SOL (wSOL)</CardTitle>
+					<CardDescription>
+						Wrap native SOL into wSOL and unwrap it back using the <code>useWrapSol</code> hook.
+					</CardDescription>
+				</div>
+			</CardHeader>
+			<CardContent className="space-y-4">
+				<div className="grid gap-2 text-sm text-muted-foreground">
+					<div>
+						<span className="font-medium text-foreground">Mint:</span>{' '}
+						<code className="break-all">{WRAPPED_SOL_MINT}</code>
+					</div>
+					<div>
+						<span className="font-medium text-foreground">Owner:</span>{' '}
+						{owner ? <code className="break-all">{owner}</code> : 'Connect a wallet'}
+					</div>
+				</div>
+
+				{/* Balance Section */}
+				<div className="space-y-2">
+					<div className="flex flex-wrap gap-2">
+						<Button
+							disabled={!isWalletConnected || refreshing || isFetching}
+							onClick={() => void refresh()}
+							type="button"
+							variant="secondary"
+						>
+							{refreshing || isFetching ? 'Refreshing...' : 'Refresh Balance'}
+						</Button>
+					</div>
+					<div aria-live="polite" className="log-panel">
+						{status === 'error' && error
+							? `Error: ${formatError(error)}`
+							: formatWsolBalance(balance, owner)}
+					</div>
+				</div>
+
+				{/* Wrap Form */}
+				<form className="grid gap-4" onSubmit={handleWrap}>
+					<fieldset className="grid gap-4" disabled={!isWalletConnected}>
+						<div className="space-y-2">
+							<label htmlFor="wrap-amount">Amount (SOL)</label>
+							<Input
+								autoComplete="off"
+								disabled={!owner}
+								id="wrap-amount"
+								min="0"
+								onChange={(event) => setWrapAmount(event.target.value)}
+								placeholder="0.1"
+								step="0.000000001"
+								type="number"
+								value={wrapAmount}
+							/>
+						</div>
+						<div className="flex flex-wrap gap-2">
+							<Button disabled={!owner || isWrapping} type="submit">
+								{isWrapping ? 'Wrapping...' : 'Wrap SOL'}
+							</Button>
+							<Button disabled={wrapStatus === 'idle'} onClick={resetWrap} type="button" variant="ghost">
+								Reset
+							</Button>
+						</div>
+					</fieldset>
+				</form>
+				<div aria-live="polite" className="log-panel">
+					{getWrapStatus()}
+				</div>
+
+				{/* Unwrap Section */}
+				<div className="space-y-2 border-t pt-4">
+					<h4 className="font-medium">Unwrap wSOL</h4>
+					<p className="text-sm text-muted-foreground">
+						Unwrapping closes your wSOL token account and returns all SOL to your wallet.
+					</p>
+					<div className="flex flex-wrap gap-2">
+						<Button
+							disabled={!owner || isUnwrapping || !hasWsolBalance}
+							onClick={() => void handleUnwrap()}
+							type="button"
+							variant="destructive"
+						>
+							{isUnwrapping ? 'Unwrapping...' : 'Unwrap All wSOL'}
+						</Button>
+						<Button disabled={unwrapStatus === 'idle'} onClick={resetUnwrap} type="button" variant="ghost">
+							Reset
+						</Button>
+					</div>
+				</div>
+			</CardContent>
+			<CardFooter>
+				<div aria-live="polite" className="log-panel w-full">
+					{getUnwrapStatus()}
+				</div>
+			</CardFooter>
+		</Card>
+	);
+}

--- a/packages/client/src/client/createClient.ts
+++ b/packages/client/src/client/createClient.ts
@@ -100,6 +100,9 @@ export function createClient(config: SolanaClientConfig): SolanaClient {
 		get transaction() {
 			return helpers.transaction;
 		},
+		get wsol() {
+			return helpers.wsol;
+		},
 		prepareTransaction: helpers.prepareTransaction,
 		watchers,
 	};

--- a/packages/client/src/controllers/wsolController.ts
+++ b/packages/client/src/controllers/wsolController.ts
@@ -1,0 +1,138 @@
+import type { SolTransferSendOptions } from '../features/sol';
+import type { WsolHelper, WsolUnwrapPrepareConfig, WsolWrapPrepareConfig } from '../features/wsol';
+import { type AsyncState, createAsyncState, createInitialAsyncState } from '../state/asyncState';
+
+type WsolWrapSignature = Awaited<ReturnType<WsolHelper['sendWrap']>>;
+type WsolUnwrapSignature = Awaited<ReturnType<WsolHelper['sendUnwrap']>>;
+
+type Listener = () => void;
+
+export type WsolControllerConfig = Readonly<{
+	authorityProvider?: () => WsolWrapPrepareConfig['authority'] | undefined;
+	helper: WsolHelper;
+}>;
+
+export type WsolWrapInput = Omit<WsolWrapPrepareConfig, 'authority'> & {
+	authority?: WsolWrapPrepareConfig['authority'];
+};
+
+export type WsolUnwrapInput = Omit<WsolUnwrapPrepareConfig, 'authority'> & {
+	authority?: WsolUnwrapPrepareConfig['authority'];
+};
+
+export type WsolController = Readonly<{
+	getHelper(): WsolHelper;
+	getWrapState(): AsyncState<WsolWrapSignature>;
+	getUnwrapState(): AsyncState<WsolUnwrapSignature>;
+	resetWrap(): void;
+	resetUnwrap(): void;
+	wrap(config: WsolWrapInput, options?: SolTransferSendOptions): Promise<WsolWrapSignature>;
+	unwrap(config: WsolUnwrapInput, options?: SolTransferSendOptions): Promise<WsolUnwrapSignature>;
+	subscribeWrap(listener: Listener): () => void;
+	subscribeUnwrap(listener: Listener): () => void;
+}>;
+
+function ensureAuthority<T extends WsolWrapInput | WsolUnwrapInput>(
+	input: T,
+	resolveDefault?: () => WsolWrapPrepareConfig['authority'] | undefined,
+): T & { authority: WsolWrapPrepareConfig['authority'] } {
+	const authority = input.authority ?? resolveDefault?.();
+	if (!authority) {
+		throw new Error('Connect a wallet or supply an `authority` before wrapping/unwrapping SOL.');
+	}
+	return {
+		...input,
+		authority,
+	};
+}
+
+export function createWsolController(config: WsolControllerConfig): WsolController {
+	const wrapListeners = new Set<Listener>();
+	const unwrapListeners = new Set<Listener>();
+	const helper = config.helper;
+	const authorityProvider = config.authorityProvider;
+	let wrapState: AsyncState<WsolWrapSignature> = createInitialAsyncState<WsolWrapSignature>();
+	let unwrapState: AsyncState<WsolUnwrapSignature> = createInitialAsyncState<WsolUnwrapSignature>();
+
+	function notifyWrap() {
+		for (const listener of wrapListeners) {
+			listener();
+		}
+	}
+
+	function notifyUnwrap() {
+		for (const listener of unwrapListeners) {
+			listener();
+		}
+	}
+
+	function setWrapState(next: AsyncState<WsolWrapSignature>) {
+		wrapState = next;
+		notifyWrap();
+	}
+
+	function setUnwrapState(next: AsyncState<WsolUnwrapSignature>) {
+		unwrapState = next;
+		notifyUnwrap();
+	}
+
+	async function wrap(input: WsolWrapInput, options?: SolTransferSendOptions): Promise<WsolWrapSignature> {
+		const request = ensureAuthority(input, authorityProvider);
+		setWrapState(createAsyncState<WsolWrapSignature>('loading'));
+		try {
+			const signature = await helper.sendWrap(request, options);
+			setWrapState(createAsyncState<WsolWrapSignature>('success', { data: signature }));
+			return signature;
+		} catch (error) {
+			setWrapState(createAsyncState<WsolWrapSignature>('error', { error }));
+			throw error;
+		}
+	}
+
+	async function unwrap(input: WsolUnwrapInput, options?: SolTransferSendOptions): Promise<WsolUnwrapSignature> {
+		const request = ensureAuthority(input, authorityProvider);
+		setUnwrapState(createAsyncState<WsolUnwrapSignature>('loading'));
+		try {
+			const signature = await helper.sendUnwrap(request, options);
+			setUnwrapState(createAsyncState<WsolUnwrapSignature>('success', { data: signature }));
+			return signature;
+		} catch (error) {
+			setUnwrapState(createAsyncState<WsolUnwrapSignature>('error', { error }));
+			throw error;
+		}
+	}
+
+	function subscribeWrap(listener: Listener): () => void {
+		wrapListeners.add(listener);
+		return () => {
+			wrapListeners.delete(listener);
+		};
+	}
+
+	function subscribeUnwrap(listener: Listener): () => void {
+		unwrapListeners.add(listener);
+		return () => {
+			unwrapListeners.delete(listener);
+		};
+	}
+
+	function resetWrap() {
+		setWrapState(createInitialAsyncState<WsolWrapSignature>());
+	}
+
+	function resetUnwrap() {
+		setUnwrapState(createInitialAsyncState<WsolUnwrapSignature>());
+	}
+
+	return {
+		getHelper: () => helper,
+		getWrapState: () => wrapState,
+		getUnwrapState: () => unwrapState,
+		resetWrap,
+		resetUnwrap,
+		wrap,
+		unwrap,
+		subscribeWrap,
+		subscribeUnwrap,
+	};
+}

--- a/packages/client/src/features/wsol.ts
+++ b/packages/client/src/features/wsol.ts
@@ -1,0 +1,393 @@
+import { getBase58Decoder } from '@solana/codecs-strings';
+import {
+	type Address,
+	address,
+	appendTransactionMessageInstruction,
+	appendTransactionMessageInstructions,
+	type Blockhash,
+	type Commitment,
+	createTransactionMessage,
+	createTransactionPlanExecutor,
+	getBase64EncodedWireTransaction,
+	isSolanaError,
+	isTransactionSendingSigner,
+	pipe,
+	SOLANA_ERROR__TRANSACTION_ERROR__ALREADY_PROCESSED,
+	setTransactionMessageFeePayer,
+	setTransactionMessageLifetimeUsingBlockhash,
+	signAndSendTransactionMessageWithSigners,
+	signature,
+	signTransactionMessageWithSigners,
+	singleTransactionPlan,
+	type TransactionPlan,
+	type TransactionSigner,
+	type TransactionVersion,
+} from '@solana/kit';
+import { getTransferSolInstruction } from '@solana-program/system';
+import {
+	findAssociatedTokenPda,
+	getCloseAccountInstruction,
+	getCreateAssociatedTokenIdempotentInstruction,
+	getSyncNativeInstruction,
+	TOKEN_PROGRAM_ADDRESS,
+} from '@solana-program/token';
+
+import { lamportsMath } from '../numeric/lamports';
+import type { SolanaClientRuntime } from '../rpc/types';
+import { createWalletTransactionSigner, isWalletSession, resolveSignerMode } from '../signers/walletTransactionSigner';
+import type { WalletSession } from '../wallet/types';
+import type { SolTransferSendOptions } from './sol';
+
+/** Wrapped SOL mint address (same on all clusters). */
+export const WRAPPED_SOL_MINT = address('So11111111111111111111111111111111111111112');
+
+type BlockhashLifetime = Readonly<{
+	blockhash: Blockhash;
+	lastValidBlockHeight: bigint;
+}>;
+
+type WsolAuthority = TransactionSigner<string> | WalletSession;
+
+type SignableWsolTransactionMessage = Parameters<typeof signTransactionMessageWithSigners>[0];
+
+export type WsolWrapPrepareConfig = Readonly<{
+	/** Amount of SOL to wrap (in lamports, SOL string, or number). */
+	amount: bigint | number | string;
+	/** Authority that signs the transaction (wallet session or raw signer). */
+	authority: WsolAuthority;
+	/** Commitment level for the transaction. */
+	commitment?: Commitment;
+	/** Optional existing blockhash lifetime to reuse. */
+	lifetime?: BlockhashLifetime;
+	/** Owner of the wSOL account. Defaults to authority address. */
+	owner?: Address | string;
+	/** Transaction version (defaults to 0). */
+	transactionVersion?: TransactionVersion;
+}>;
+
+export type WsolUnwrapPrepareConfig = Readonly<{
+	/** Authority that signs the transaction (wallet session or raw signer). */
+	authority: WsolAuthority;
+	/** Commitment level for the transaction. */
+	commitment?: Commitment;
+	/** Optional existing blockhash lifetime to reuse. */
+	lifetime?: BlockhashLifetime;
+	/** Owner of the wSOL account. Defaults to authority address. */
+	owner?: Address | string;
+	/** Transaction version (defaults to 0). */
+	transactionVersion?: TransactionVersion;
+}>;
+
+type PreparedWsolWrap = Readonly<{
+	amount: bigint;
+	ataAddress: Address;
+	commitment?: Commitment;
+	lifetime: BlockhashLifetime;
+	message: SignableWsolTransactionMessage;
+	mode: 'partial' | 'send';
+	owner: Address;
+	plan?: TransactionPlan;
+	signer: TransactionSigner;
+}>;
+
+type PreparedWsolUnwrap = Readonly<{
+	ataAddress: Address;
+	commitment?: Commitment;
+	lifetime: BlockhashLifetime;
+	message: SignableWsolTransactionMessage;
+	mode: 'partial' | 'send';
+	owner: Address;
+	plan?: TransactionPlan;
+	signer: TransactionSigner;
+}>;
+
+function ensureAddress(value: Address | string | undefined, fallback?: Address): Address {
+	if (value) {
+		return typeof value === 'string' ? address(value) : value;
+	}
+	if (!fallback) {
+		throw new Error('An address value was expected but not provided.');
+	}
+	return fallback;
+}
+
+async function resolveLifetime(
+	runtime: SolanaClientRuntime,
+	commitment?: Commitment,
+	fallback?: BlockhashLifetime,
+): Promise<BlockhashLifetime> {
+	if (fallback) {
+		return fallback;
+	}
+	const { value } = await runtime.rpc.getLatestBlockhash({ commitment }).send();
+	return value;
+}
+
+function resolveSigner(
+	authority: WsolAuthority,
+	commitment?: Commitment,
+): { mode: 'partial' | 'send'; signer: TransactionSigner } {
+	if (isWalletSession(authority)) {
+		const { signer, mode } = createWalletTransactionSigner(authority, { commitment });
+		return { mode, signer };
+	}
+	return { mode: resolveSignerMode(authority), signer: authority };
+}
+
+function toLamportAmount(input: bigint | number | string): bigint {
+	return lamportsMath.fromLamports(input);
+}
+
+export type WsolHelper = Readonly<{
+	/** Derive the wSOL Associated Token Address for an owner. */
+	deriveWsolAddress(owner: Address | string): Promise<Address>;
+	/** Fetch the wSOL balance for an owner. */
+	fetchWsolBalance(owner: Address | string, commitment?: Commitment): Promise<WsolBalance>;
+	/** Prepare a wrap transaction without sending. */
+	prepareWrap(config: WsolWrapPrepareConfig): Promise<PreparedWsolWrap>;
+	/** Prepare an unwrap transaction without sending. */
+	prepareUnwrap(config: WsolUnwrapPrepareConfig): Promise<PreparedWsolUnwrap>;
+	/** Send a previously prepared wrap transaction. */
+	sendPreparedWrap(
+		prepared: PreparedWsolWrap,
+		options?: SolTransferSendOptions,
+	): Promise<ReturnType<typeof signature>>;
+	/** Send a previously prepared unwrap transaction. */
+	sendPreparedUnwrap(
+		prepared: PreparedWsolUnwrap,
+		options?: SolTransferSendOptions,
+	): Promise<ReturnType<typeof signature>>;
+	/** Wrap SOL to wSOL in one call. */
+	sendWrap(config: WsolWrapPrepareConfig, options?: SolTransferSendOptions): Promise<ReturnType<typeof signature>>;
+	/** Unwrap wSOL to SOL in one call (closes the wSOL account). */
+	sendUnwrap(
+		config: WsolUnwrapPrepareConfig,
+		options?: SolTransferSendOptions,
+	): Promise<ReturnType<typeof signature>>;
+}>;
+
+export type WsolBalance = Readonly<{
+	amount: bigint;
+	ataAddress: Address;
+	exists: boolean;
+}>;
+
+/** Creates helpers for wrapping native SOL to wSOL and unwrapping back. */
+export function createWsolHelper(runtime: SolanaClientRuntime): WsolHelper {
+	const tokenProgram = address(TOKEN_PROGRAM_ADDRESS);
+
+	async function deriveWsolAddress(owner: Address | string): Promise<Address> {
+		const [ata] = await findAssociatedTokenPda({
+			mint: WRAPPED_SOL_MINT,
+			owner: ensureAddress(owner),
+			tokenProgram,
+		});
+		return ata;
+	}
+
+	async function fetchWsolBalance(owner: Address | string, commitment?: Commitment): Promise<WsolBalance> {
+		const ataAddress = await deriveWsolAddress(owner);
+		try {
+			const { value } = await runtime.rpc.getTokenAccountBalance(ataAddress, { commitment }).send();
+			const amount = BigInt(value.amount);
+			return {
+				amount,
+				ataAddress,
+				exists: true,
+			};
+		} catch {
+			return {
+				amount: 0n,
+				ataAddress,
+				exists: false,
+			};
+		}
+	}
+
+	async function prepareWrap(config: WsolWrapPrepareConfig): Promise<PreparedWsolWrap> {
+		const commitment = config.commitment;
+		const lifetime = await resolveLifetime(runtime, commitment, config.lifetime);
+		const { signer, mode } = resolveSigner(config.authority, commitment);
+		const owner = ensureAddress(config.owner, signer.address);
+		const amount = toLamportAmount(config.amount);
+		const ataAddress = await deriveWsolAddress(owner);
+
+		// Instructions:
+		// 1. Create ATA if it doesn't exist (idempotent)
+		// 2. Transfer SOL to ATA
+		// 3. Sync native to update token balance
+		const instructions = [
+			getCreateAssociatedTokenIdempotentInstruction({
+				ata: ataAddress,
+				mint: WRAPPED_SOL_MINT,
+				owner,
+				payer: signer,
+				tokenProgram,
+			}),
+			getTransferSolInstruction({
+				amount,
+				destination: ataAddress,
+				source: signer,
+			}),
+			getSyncNativeInstruction({
+				account: ataAddress,
+			}),
+		];
+
+		const message = pipe(
+			createTransactionMessage({ version: config.transactionVersion ?? 0 }),
+			(m) => setTransactionMessageFeePayer(signer.address, m),
+			(m) => setTransactionMessageLifetimeUsingBlockhash(lifetime, m),
+			(m) => appendTransactionMessageInstructions(instructions, m),
+		);
+
+		return {
+			amount,
+			ataAddress,
+			commitment,
+			lifetime,
+			message,
+			mode,
+			owner,
+			plan: singleTransactionPlan(message),
+			signer,
+		};
+	}
+
+	async function prepareUnwrap(config: WsolUnwrapPrepareConfig): Promise<PreparedWsolUnwrap> {
+		const commitment = config.commitment;
+		const lifetime = await resolveLifetime(runtime, commitment, config.lifetime);
+		const { signer, mode } = resolveSigner(config.authority, commitment);
+		const owner = ensureAddress(config.owner, signer.address);
+		const ataAddress = await deriveWsolAddress(owner);
+
+		// Close account instruction transfers remaining lamports to destination
+		const instruction = getCloseAccountInstruction({
+			account: ataAddress,
+			destination: owner,
+			owner: signer,
+		});
+
+		const message = pipe(
+			createTransactionMessage({ version: config.transactionVersion ?? 0 }),
+			(m) => setTransactionMessageFeePayer(signer.address, m),
+			(m) => setTransactionMessageLifetimeUsingBlockhash(lifetime, m),
+			(m) => appendTransactionMessageInstruction(instruction, m),
+		);
+
+		return {
+			ataAddress,
+			commitment,
+			lifetime,
+			message,
+			mode,
+			owner,
+			plan: singleTransactionPlan(message),
+			signer,
+		};
+	}
+
+	async function sendPreparedTransaction(
+		prepared: PreparedWsolWrap | PreparedWsolUnwrap,
+		options: SolTransferSendOptions = {},
+	): Promise<ReturnType<typeof signature>> {
+		if (prepared.mode === 'send' && isTransactionSendingSigner(prepared.signer)) {
+			const signatureBytes = await signAndSendTransactionMessageWithSigners(prepared.message, {
+				abortSignal: options.abortSignal,
+				minContextSlot: options.minContextSlot,
+			});
+			const base58Decoder = getBase58Decoder();
+			return signature(base58Decoder.decode(signatureBytes));
+		}
+
+		const commitment = options.commitment ?? prepared.commitment;
+		const maxRetries =
+			options.maxRetries === undefined
+				? undefined
+				: typeof options.maxRetries === 'bigint'
+					? options.maxRetries
+					: BigInt(options.maxRetries);
+		let latestSignature: ReturnType<typeof signature> | null = null;
+		const executor = createTransactionPlanExecutor({
+			async executeTransactionMessage(message, config = {}) {
+				const signed = await signTransactionMessageWithSigners(message as SignableWsolTransactionMessage, {
+					abortSignal: config.abortSignal ?? options.abortSignal,
+					minContextSlot: options.minContextSlot,
+				});
+				const wire = getBase64EncodedWireTransaction(signed);
+				const response = await runtime.rpc
+					.sendTransaction(wire, {
+						encoding: 'base64',
+						maxRetries,
+						preflightCommitment: commitment,
+						skipPreflight: options.skipPreflight,
+					})
+					.send({ abortSignal: config.abortSignal ?? options.abortSignal });
+				latestSignature = signature(response);
+				return { transaction: signed };
+			},
+		});
+		await executor(prepared.plan ?? singleTransactionPlan(prepared.message), { abortSignal: options.abortSignal });
+		if (!latestSignature) {
+			throw new Error('Failed to resolve transaction signature.');
+		}
+		return latestSignature;
+	}
+
+	async function sendPreparedWrap(
+		prepared: PreparedWsolWrap,
+		options?: SolTransferSendOptions,
+	): Promise<ReturnType<typeof signature>> {
+		return sendPreparedTransaction(prepared, options);
+	}
+
+	async function sendPreparedUnwrap(
+		prepared: PreparedWsolUnwrap,
+		options?: SolTransferSendOptions,
+	): Promise<ReturnType<typeof signature>> {
+		return sendPreparedTransaction(prepared, options);
+	}
+
+	async function sendWrap(
+		config: WsolWrapPrepareConfig,
+		options?: SolTransferSendOptions,
+	): Promise<ReturnType<typeof signature>> {
+		const prepared = await prepareWrap(config);
+		try {
+			return await sendPreparedWrap(prepared, options);
+		} catch (error) {
+			if (isSolanaError(error, SOLANA_ERROR__TRANSACTION_ERROR__ALREADY_PROCESSED)) {
+				const retriedPrepared = await prepareWrap({ ...config, lifetime: undefined });
+				return await sendPreparedWrap(retriedPrepared, options);
+			}
+			throw error;
+		}
+	}
+
+	async function sendUnwrap(
+		config: WsolUnwrapPrepareConfig,
+		options?: SolTransferSendOptions,
+	): Promise<ReturnType<typeof signature>> {
+		const prepared = await prepareUnwrap(config);
+		try {
+			return await sendPreparedUnwrap(prepared, options);
+		} catch (error) {
+			if (isSolanaError(error, SOLANA_ERROR__TRANSACTION_ERROR__ALREADY_PROCESSED)) {
+				const retriedPrepared = await prepareUnwrap({ ...config, lifetime: undefined });
+				return await sendPreparedUnwrap(retriedPrepared, options);
+			}
+			throw error;
+		}
+	}
+
+	return {
+		deriveWsolAddress,
+		fetchWsolBalance,
+		prepareUnwrap,
+		prepareWrap,
+		sendPreparedUnwrap,
+		sendPreparedWrap,
+		sendUnwrap,
+		sendWrap,
+	};
+}

--- a/packages/client/src/index.ts
+++ b/packages/client/src/index.ts
@@ -39,6 +39,13 @@ export {
 	type WithdrawInput,
 } from './controllers/stakeController';
 export {
+	createWsolController,
+	type WsolController,
+	type WsolControllerConfig,
+	type WsolUnwrapInput,
+	type WsolWrapInput,
+} from './controllers/wsolController';
+export {
 	createSolTransferHelper,
 	type SolTransferHelper,
 	type SolTransferPrepareConfig,
@@ -75,6 +82,14 @@ export {
 	type TransactionSendOptions,
 	type TransactionSignOptions,
 } from './features/transactions';
+export {
+	createWsolHelper,
+	WRAPPED_SOL_MINT,
+	type WsolBalance,
+	type WsolHelper,
+	type WsolUnwrapPrepareConfig,
+	type WsolWrapPrepareConfig,
+} from './features/wsol';
 export {
 	createTokenAmount,
 	type FormatAmountOptions,

--- a/packages/client/src/types.ts
+++ b/packages/client/src/types.ts
@@ -14,6 +14,7 @@ import type { SolTransferHelper } from './features/sol';
 import type { SplTokenHelper, SplTokenHelperConfig } from './features/spl';
 import type { StakeHelper } from './features/stake';
 import type { TransactionHelper } from './features/transactions';
+import type { WsolHelper } from './features/wsol';
 import type { SolanaRpcClient } from './rpc/createSolanaRpcClient';
 import type { SolanaClientRuntime } from './rpc/types';
 import type { PrepareTransactionMessage, PrepareTransactionOptions } from './transactions/prepareTransaction';
@@ -277,6 +278,7 @@ export type ClientHelpers = Readonly<{
 	splToken(config: SplTokenHelperConfig): SplTokenHelper;
 	stake: StakeHelper;
 	transaction: TransactionHelper;
+	wsol: WsolHelper;
 	prepareTransaction<TMessage extends PrepareTransactionMessage>(
 		config: PrepareTransactionOptions<TMessage>,
 	): Promise<TMessage & TransactionMessageWithBlockhashLifetime>;
@@ -298,5 +300,6 @@ export type SolanaClient = Readonly<{
 	SplHelper(config: SplTokenHelperConfig): SplTokenHelper;
 	stake: StakeHelper;
 	transaction: TransactionHelper;
+	wsol: WsolHelper;
 	prepareTransaction: ClientHelpers['prepareTransaction'];
 }>;

--- a/packages/react-hooks/src/index.ts
+++ b/packages/react-hooks/src/index.ts
@@ -45,6 +45,8 @@ export type {
 	UseWalletReturnType,
 	UseWalletSessionParameters,
 	UseWalletSessionReturnType,
+	UseWrapSolParameters,
+	UseWrapSolReturnType,
 } from './hooks';
 export {
 	useAccount,
@@ -65,6 +67,7 @@ export {
 	useWallet,
 	useWalletActions,
 	useWalletSession,
+	useWrapSol,
 } from './hooks';
 export { SolanaQueryProvider } from './QueryProvider';
 export type { QueryStatus, SolanaQueryResult, UseSolanaRpcQueryOptions } from './query';


### PR DESCRIPTION
## Summary

- Add `WsolHelper` with `sendWrap()` and `sendUnwrap()` methods for wrapping/unwrapping SOL
- Add `useWrapSol()` React hook with balance tracking and status management  
- Export `WRAPPED_SOL_MINT` constant and all related types
- Add `WrapSolPanel` example component to vite-react demo

## Usage

```ts
// Client helper
const wsol = client.wsol;
await wsol.sendWrap({ amount: 1_000_000_000n, authority: session });
await wsol.sendUnwrap({ authority: session });

// React hook
const { wrap, unwrap, balance, isWrapping, isUnwrapping } = useWrapSol();
await wrap({ amount: 1_000_000_000n });
await unwrap({});
```

## Test plan

- [x] Build passes
- [x] Typecheck passes
- [x] Tested wrap/unwrap in vite-react example app

Closes #116