### PR TITLE
docs: add comprehensive JSDoc documentation

### DIFF
--- a/.changeset/comprehensive-jsdoc-docs.md
+++ b/.changeset/comprehensive-jsdoc-docs.md
@@ -1,0 +1,6 @@
+---
+'@solana/client': patch
+'@solana/react-hooks': patch
+---
+
+Add comprehensive JSDoc documentation for LLM-ready API docs

--- a/packages/client/src/features/sol.ts
+++ b/packages/client/src/features/sol.ts
@@ -28,40 +28,100 @@ import type { SolanaClientRuntime } from '../rpc/types';
 import { createWalletTransactionSigner, isWalletSession, resolveSignerMode } from '../signers/walletTransactionSigner';
 import type { WalletSession } from '../wallet/types';
 
+/**
+ * Blockhash and last valid block height for transaction lifetime.
+ * Used to ensure transactions expire after a certain block height.
+ */
 type BlockhashLifetime = Readonly<{
 	blockhash: Blockhash;
 	lastValidBlockHeight: bigint;
 }>;
 
+/**
+ * Amount of SOL to transfer. Can be specified as:
+ * - `bigint`: Raw lamports (1 SOL = 1_000_000_000 lamports)
+ * - `number`: SOL amount as decimal (e.g., 1.5 for 1.5 SOL)
+ * - `string`: SOL amount as string (e.g., "1.5" for 1.5 SOL)
+ */
 type SolTransferAmount = bigint | number | string;
 
+/**
+ * Authority that signs the SOL transfer transaction.
+ * Can be either a connected wallet session or a raw transaction signer.
+ */
 type SolTransferAuthority = TransactionSigner<string> | WalletSession;
 
 type SignableSolTransactionMessage = Parameters<typeof signTransactionMessageWithSigners>[0];
 
+/**
+ * Configuration for preparing a SOL transfer transaction.
+ *
+ * @example
+ * ```ts
+ * const config: SolTransferPrepareConfig = {
+ *   amount: 1_000_000_000n, // 1 SOL in lamports
+ *   authority: walletSession,
+ *   destination: 'RecipientAddress...',
+ *   commitment: 'confirmed',
+ * };
+ * ```
+ */
 export type SolTransferPrepareConfig = Readonly<{
+	/** Amount of SOL to transfer in lamports, decimal SOL, or string SOL. */
 	amount: SolTransferAmount;
+	/** Authority that signs the transaction. Can be a WalletSession or raw TransactionSigner. */
 	authority: SolTransferAuthority;
+	/** Commitment level for fetching blockhash and sending transaction. Defaults to client commitment. */
 	commitment?: Commitment;
+	/** Destination wallet address to receive the SOL. */
 	destination: Address | string;
+	/** Optional pre-fetched blockhash lifetime. If not provided, one will be fetched. */
 	lifetime?: BlockhashLifetime;
+	/** Transaction version. Defaults to 0 (legacy). */
 	transactionVersion?: TransactionVersion;
 }>;
 
+/**
+ * Options for sending a SOL transfer transaction.
+ *
+ * @example
+ * ```ts
+ * const options: SolTransferSendOptions = {
+ *   commitment: 'confirmed',
+ *   maxRetries: 3,
+ *   skipPreflight: false,
+ * };
+ * ```
+ */
 export type SolTransferSendOptions = Readonly<{
+	/** AbortSignal to cancel the transaction. */
 	abortSignal?: AbortSignal;
+	/** Commitment level for transaction confirmation. */
 	commitment?: Commitment;
+	/** Maximum number of times to retry sending the transaction. */
 	maxRetries?: bigint | number;
+	/** Minimum slot that the request can be evaluated at. */
 	minContextSlot?: Slot;
+	/** If true, skip the preflight transaction checks. */
 	skipPreflight?: boolean;
 }>;
 
+/**
+ * A prepared SOL transfer transaction ready to be signed and sent.
+ * Contains the transaction message, signer, and metadata needed for submission.
+ */
 type PreparedSolTransfer = Readonly<{
+	/** Commitment level used for this transaction. */
 	commitment?: Commitment;
+	/** Blockhash lifetime for transaction expiration. */
 	lifetime: BlockhashLifetime;
+	/** The unsigned transaction message. */
 	message: SignableSolTransactionMessage;
+	/** Signing mode: 'send' for wallets that sign+send, 'partial' for separate signing. */
 	mode: 'partial' | 'send';
+	/** The transaction signer. */
 	signer: TransactionSigner;
+	/** Transaction plan for execution. */
 	plan?: TransactionPlan;
 }>;
 
@@ -96,19 +156,74 @@ function toLamportAmount(input: SolTransferAmount): bigint {
 	return lamportsMath.fromLamports(input);
 }
 
+/**
+ * Helper interface for native SOL transfers using the System Program.
+ * Provides methods to prepare, sign, and send SOL transfer transactions.
+ *
+ * @example
+ * ```ts
+ * import { createSolTransferHelper } from '@solana/client';
+ *
+ * const helper = createSolTransferHelper(runtime);
+ *
+ * // Simple transfer
+ * const signature = await helper.sendTransfer({
+ *   amount: 1_000_000_000n, // 1 SOL
+ *   authority: walletSession,
+ *   destination: 'RecipientAddress...',
+ * });
+ *
+ * // Or prepare and send separately
+ * const prepared = await helper.prepareTransfer({ ... });
+ * const signature = await helper.sendPreparedTransfer(prepared);
+ * ```
+ */
 export type SolTransferHelper = Readonly<{
+	/**
+	 * Prepares a SOL transfer transaction without sending it.
+	 * Use this when you need to inspect or modify the transaction before sending.
+	 */
 	prepareTransfer(config: SolTransferPrepareConfig): Promise<PreparedSolTransfer>;
+	/**
+	 * Sends a previously prepared SOL transfer transaction.
+	 * Use this after prepareTransfer() to submit the transaction.
+	 */
 	sendPreparedTransfer(
 		prepared: PreparedSolTransfer,
 		options?: SolTransferSendOptions,
 	): Promise<ReturnType<typeof signature>>;
+	/**
+	 * Prepares and sends a SOL transfer in one call.
+	 * This is the simplest way to transfer SOL.
+	 */
 	sendTransfer(
 		config: SolTransferPrepareConfig,
 		options?: SolTransferSendOptions,
 	): Promise<ReturnType<typeof signature>>;
 }>;
 
-/** Creates documented helpers that build and submit System Program SOL transfers. */
+/**
+ * Creates helpers for building and submitting native SOL transfers via the System Program.
+ *
+ * @param runtime - The Solana client runtime with RPC connection.
+ * @returns A SolTransferHelper with methods to prepare and send SOL transfers.
+ *
+ * @example
+ * ```ts
+ * import { createClient } from '@solana/client';
+ *
+ * const client = createClient({ cluster: 'devnet' });
+ * const helper = client.helpers.sol;
+ *
+ * // Transfer 0.5 SOL
+ * const sig = await helper.sendTransfer({
+ *   amount: 0.5, // Can use decimal SOL
+ *   authority: session,
+ *   destination: 'RecipientAddress...',
+ * });
+ * console.log('Transfer signature:', sig);
+ * ```
+ */
 export function createSolTransferHelper(runtime: SolanaClientRuntime): SolTransferHelper {
 	async function prepareTransfer(config: SolTransferPrepareConfig): Promise<PreparedSolTransfer> {
 		const commitment = config.commitment;

--- a/packages/client/src/features/stake.ts
+++ b/packages/client/src/features/stake.ts
@@ -36,16 +36,44 @@ import type { SolanaClientRuntime } from '../rpc/types';
 import { createWalletTransactionSigner, isWalletSession, resolveSignerMode } from '../signers/walletTransactionSigner';
 import type { WalletSession } from '../wallet/types';
 
+/**
+ * Blockhash and last valid block height for transaction lifetime.
+ * Used to ensure transactions expire after a certain block height.
+ */
 type BlockhashLifetime = Readonly<{
 	blockhash: Blockhash;
 	lastValidBlockHeight: bigint;
 }>;
 
+/**
+ * Amount of SOL to stake. Can be specified as:
+ * - `bigint`: Raw lamports (1 SOL = 1_000_000_000 lamports)
+ * - `number`: SOL amount as decimal (e.g., 1.5 for 1.5 SOL)
+ * - `string`: SOL amount as string (e.g., "1.5" for 1.5 SOL)
+ */
 type StakeAmount = bigint | number | string;
 
+/**
+ * Authority that signs staking transactions.
+ * Can be either a connected wallet session or a raw transaction signer.
+ */
 type StakeAuthority = TransactionSigner<string> | WalletSession;
 
+/**
+ * Represents a stake account with its delegation and metadata.
+ * Returned by getStakeAccounts() when querying stake positions.
+ *
+ * @example
+ * ```ts
+ * const accounts = await stakeHelper.getStakeAccounts(walletAddress);
+ * for (const acc of accounts) {
+ *   const delegation = acc.account.data.parsed.info.stake?.delegation;
+ *   console.log(`Staked ${acc.account.lamports} to validator ${delegation?.voter}`);
+ * }
+ * ```
+ */
 export type StakeAccount = {
+	/** The stake account's public key address. */
 	pubkey: Address;
 	account: {
 		data: {
@@ -53,27 +81,38 @@ export type StakeAccount = {
 				info: {
 					stake?: {
 						delegation?: {
+							/** The validator vote account receiving the stake. */
 							voter: string;
+							/** Amount of lamports delegated. */
 							stake: string;
+							/** Epoch when stake became active. */
 							activationEpoch: string;
+							/** Epoch when stake will deactivate (max value if active). */
 							deactivationEpoch: string;
 						};
 					};
 					meta?: {
+						/** Rent-exempt reserve in lamports. */
 						rentExemptReserve: string;
 						authorized: {
+							/** Address authorized to delegate/undelegate. */
 							staker: string;
+							/** Address authorized to withdraw. */
 							withdrawer: string;
 						};
 						lockup: {
+							/** Unix timestamp when lockup expires (0 if none). */
 							unixTimestamp: number;
+							/** Epoch when lockup expires (0 if none). */
 							epoch: number;
+							/** Custodian who can modify lockup (system program if none). */
 							custodian: string;
 						};
 					};
 				};
 			};
 		};
+		/** Total lamports in the stake account. */
 		lamports: bigint;
 	};
 };
@@ -87,43 +126,118 @@ const SYSVAR_STAKE_HISTORY: Address = 'SysvarStakeHistory11111111111111111111111
 const UNUSED_STAKE_CONFIG_ACC: Address = 'StakeConfig11111111111111111111111111111111' as Address;
 const STAKE_STATE_LEN = 200;
 
+/**
+ * Configuration for preparing a stake delegation transaction.
+ * Creates a new stake account and delegates it to a validator.
+ *
+ * @example
+ * ```ts
+ * const config: StakePrepareConfig = {
+ *   amount: 10, // Stake 10 SOL
+ *   authority: walletSession,
+ *   validatorId: 'ValidatorVoteAccountAddress...',
+ * };
+ * ```
+ */
 export type StakePrepareConfig = Readonly<{
+	/** Amount of SOL to stake in lamports, decimal SOL, or string SOL. */
 	amount: StakeAmount;
+	/** Authority that signs the transaction. Will be set as staker and withdrawer. */
 	authority: StakeAuthority;
+	/** Commitment level for RPC calls. */
 	commitment?: Commitment;
+	/** Optional pre-fetched blockhash lifetime. */
 	lifetime?: BlockhashLifetime;
+	/** Transaction version. Defaults to 0 (legacy). */
 	transactionVersion?: TransactionVersion;
+	/** The validator's vote account address to delegate stake to. */
 	validatorId: Address | string;
 }>;
 
+/**
+ * Options for sending stake-related transactions.
+ *
+ * @example
+ * ```ts
+ * const options: StakeSendOptions = {
+ *   commitment: 'confirmed',
+ *   maxRetries: 3,
+ * };
+ * ```
+ */
 export type StakeSendOptions = Readonly<{
+	/** AbortSignal to cancel the transaction. */
 	abortSignal?: AbortSignal;
+	/** Commitment level for transaction confirmation. */
 	commitment?: Commitment;
+	/** Maximum number of times to retry sending the transaction. */
 	maxRetries?: bigint | number;
+	/** Minimum slot that the request can be evaluated at. */
 	minContextSlot?: Slot;
+	/** If true, skip the preflight transaction checks. */
 	skipPreflight?: boolean;
 }>;
 
+/**
+ * Configuration for preparing an unstake (deactivate) transaction.
+ * Deactivating stake begins the cooldown period before withdrawal is possible.
+ *
+ * @example
+ * ```ts
+ * const config: UnstakePrepareConfig = {
+ *   authority: walletSession,
+ *   stakeAccount: 'StakeAccountAddress...',
+ * };
+ * ```
+ */
 export type UnstakePrepareConfig = Readonly<{
+	/** Authority that signed the original stake (must be the staker). */
 	authority: StakeAuthority;
+	/** Commitment level for RPC calls. */
 	commitment?: Commitment;
+	/** Optional pre-fetched blockhash lifetime. */
 	lifetime?: BlockhashLifetime;
+	/** The stake account address to deactivate. */
 	stakeAccount: Address | string;
+	/** Transaction version. Defaults to 0 (legacy). */
 	transactionVersion?: TransactionVersion;
 }>;
 
+/** Options for sending unstake transactions. Same as StakeSendOptions. */
 export type UnstakeSendOptions = StakeSendOptions;
 
+/**
+ * Configuration for preparing a stake withdrawal transaction.
+ * Withdraws SOL from a deactivated stake account.
+ *
+ * @example
+ * ```ts
+ * const config: WithdrawPrepareConfig = {
+ *   amount: 10, // Withdraw 10 SOL
+ *   authority: walletSession,
+ *   destination: walletAddress,
+ *   stakeAccount: 'StakeAccountAddress...',
+ * };
+ * ```
+ */
 export type WithdrawPrepareConfig = Readonly<{
+	/** Amount of SOL to withdraw in lamports, decimal SOL, or string SOL. */
 	amount: StakeAmount;
+	/** Authority that signed the original stake (must be the withdrawer). */
 	authority: StakeAuthority;
+	/** Commitment level for RPC calls. */
 	commitment?: Commitment;
+	/** Destination address to receive the withdrawn SOL. */
 	destination: Address | string;
+	/** Optional pre-fetched blockhash lifetime. */
 	lifetime?: BlockhashLifetime;
+	/** The stake account address to withdraw from. */
 	stakeAccount: Address | string;
+	/** Transaction version. Defaults to 0 (legacy). */
 	transactionVersion?: TransactionVersion;
 }>;
 
+/** Options for sending withdrawal transactions. Same as StakeSendOptions. */
 export type WithdrawSendOptions = StakeSendOptions;
 
 type PreparedUnstake = Readonly<{
@@ -185,23 +299,114 @@ function toLamportAmount(input: StakeAmount): bigint {
 	return lamportsMath.fromLamports(input);
 }
 
+/**
+ * Helper interface for native SOL staking operations.
+ * Supports staking to validators, unstaking (deactivating), and withdrawing.
+ *
+ * @example
+ * ```ts
+ * import { createStakeHelper } from '@solana/client';
+ *
+ * const stakeHelper = createStakeHelper(runtime);
+ *
+ * // Stake SOL to a validator
+ * const stakeSig = await stakeHelper.sendStake({
+ *   amount: 10, // 10 SOL
+ *   authority: walletSession,
+ *   validatorId: 'ValidatorVoteAccount...',
+ * });
+ *
+ * // Query stake accounts
+ * const accounts = await stakeHelper.getStakeAccounts(walletAddress);
+ *
+ * // Deactivate stake (begin cooldown)
+ * const unstakeSig = await stakeHelper.sendUnstake({
+ *   authority: walletSession,
+ *   stakeAccount: accounts[0].pubkey,
+ * });
+ *
+ * // Withdraw after cooldown (~2-3 days on mainnet)
+ * const withdrawSig = await stakeHelper.sendWithdraw({
+ *   amount: 10,
+ *   authority: walletSession,
+ *   destination: walletAddress,
+ *   stakeAccount: accounts[0].pubkey,
+ * });
+ * ```
+ */
 export type StakeHelper = Readonly<{
+	/**
+	 * Queries all stake accounts owned by a wallet.
+	 * Optionally filter by validator to see stakes to a specific validator.
+	 */
 	getStakeAccounts(wallet: Address | string, validatorId?: Address | string): Promise<StakeAccount[]>;
+	/**
+	 * Prepares a stake transaction without sending it.
+	 * Creates a new stake account and delegates it to the specified validator.
+	 */
 	prepareStake(config: StakePrepareConfig): Promise<PreparedStake>;
+	/**
+	 * Prepares an unstake (deactivate) transaction without sending it.
+	 * Deactivating begins the cooldown period before funds can be withdrawn.
+	 */
 	prepareUnstake(config: UnstakePrepareConfig): Promise<PreparedUnstake>;
+	/**
+	 * Prepares a withdrawal transaction without sending it.
+	 * Can only withdraw from deactivated stake accounts after cooldown.
+	 */
 	prepareWithdraw(config: WithdrawPrepareConfig): Promise<PreparedWithdraw>;
+	/** Sends a previously prepared stake transaction. */
 	sendPreparedStake(prepared: PreparedStake, options?: StakeSendOptions): Promise<ReturnType<typeof signature>>;
+	/** Sends a previously prepared unstake transaction. */
 	sendPreparedUnstake(prepared: PreparedUnstake, options?: UnstakeSendOptions): Promise<ReturnType<typeof signature>>;
+	/** Sends a previously prepared withdrawal transaction. */
 	sendPreparedWithdraw(
 		prepared: PreparedWithdraw,
 		options?: WithdrawSendOptions,
 	): Promise<ReturnType<typeof signature>>;
+	/**
+	 * Prepares and sends a stake transaction in one call.
+	 * Creates a new stake account and delegates to the validator.
+	 */
 	sendStake(config: StakePrepareConfig, options?: StakeSendOptions): Promise<ReturnType<typeof signature>>;
+	/**
+	 * Prepares and sends an unstake transaction in one call.
+	 * Begins the cooldown period for the stake account.
+	 */
 	sendUnstake(config: UnstakePrepareConfig, options?: UnstakeSendOptions): Promise<ReturnType<typeof signature>>;
+	/**
+	 * Prepares and sends a withdrawal transaction in one call.
+	 * Withdraws SOL from a deactivated stake account.
+	 */
 	sendWithdraw(config: WithdrawPrepareConfig, options?: WithdrawSendOptions): Promise<ReturnType<typeof signature>>;
 }>;
 
-/** Creates helpers that build and submit native SOL staking transactions. */
+/**
+ * Creates helpers for native SOL staking operations via the Stake Program.
+ * Supports full staking lifecycle: delegate, deactivate, and withdraw.
+ *
+ * @param runtime - The Solana client runtime with RPC connection.
+ * @returns A StakeHelper with methods for staking operations.
+ *
+ * @example
+ * ```ts
+ * import { createClient } from '@solana/client';
+ *
+ * const client = createClient({ cluster: 'mainnet-beta' });
+ * const stake = client.helpers.stake;
+ *
+ * // Delegate 100 SOL to a validator
+ * const sig = await stake.sendStake({
+ *   amount: 100,
+ *   authority: session,
+ *   validatorId: 'ValidatorVoteAccount...',
+ * });
+ *
+ * // Check stake accounts
+ * const accounts = await stake.getStakeAccounts(myWallet);
+ * console.log(`Found ${accounts.length} stake accounts`);
+ * ```
+ */
 export function createStakeHelper(runtime: SolanaClientRuntime): StakeHelper {
 	async function prepareStake(config: StakePrepareConfig): Promise<PreparedStake> {
 		const commitment = config.commitment;


### PR DESCRIPTION
## Summary
- Adds comprehensive JSDoc documentation to all major exported APIs
- Includes `@example` blocks for all public functions and types
- Makes generated TypeDoc output LLM-ready and improves developer onboarding

## Packages Updated
- `@solana/client` - SOL, SPL, Stake, and wSOL feature helpers
- `@solana/react-hooks` - useStake, useSplToken, useWrapSol hooks

## Files Changed
- `packages/client/src/features/sol.ts` - SOL transfer helper documentation
- `packages/client/src/features/spl.ts` - SPL token helper documentation
- `packages/client/src/features/stake.ts` - Staking helper documentation
- `packages/client/src/features/wsol.ts` - wSOL wrap/unwrap helper documentation
- `packages/react-hooks/src/hooks.ts` - React hooks documentation

## Test Plan
- [x] Run `pnpm --filter @solana/client docs` - verified TypeDoc generates successfully
- [x] Check that all exported APIs have documentation with examples