### PR TITLE
Update footer resource links to Solana dev site

### DIFF
--- a/apps/docs/components/landing/footer.tsx
+++ b/apps/docs/components/landing/footer.tsx
@@ -35,13 +35,19 @@ export function Footer({ className }: { className?: string }) {
 								</Link>
 							</li>
 							<li>
-								<Link href="/blog" className="hover:text-primary transition-colors">
-									Blog
+								<Link
+									href="https://solana.com/developers/guides"
+									className="hover:text-primary transition-colors"
+								>
+									Guides
 								</Link>
 							</li>
 							<li>
-								<Link href="/examples" className="hover:text-primary transition-colors">
-									Examples
+								<Link
+									href="https://solana.com/developers/templates"
+									className="hover:text-primary transition-colors"
+								>
+									Templates
 								</Link>
 							</li>
 						</ul>


### PR DESCRIPTION
## Summary
- Updated footer resource links to point to Solana developer site
- Changed "Blog" → "Guides" (https://solana.com/developers/guides)
- Changed "Examples" → "Templates" (https://solana.com/developers/templates)
- All links verified and working