### PR TITLE
Set max-width for docs layout to improve sidebar alignment

### DIFF
--- a/apps/docs/app/globals.css
+++ b/apps/docs/app/globals.css
@@ -91,6 +91,7 @@
 	--color-fd-primary: #ff8c66;
 	--color-fd-background: #fdfdfc;
 	--color-fd-foreground: #171717;
+	--fd-layout-width: 1400px;
 }
 
 .dark {

--- a/apps/docs/components/landing/footer.tsx
+++ b/apps/docs/components/landing/footer.tsx
@@ -35,13 +35,19 @@ export function Footer({ className }: { className?: string }) {
 								</Link>
 							</li>
 							<li>
-								<Link href="/blog" className="hover:text-primary transition-colors">
-									Blog
+								<Link
+									href="https://solana.com/developers/guides"
+									className="hover:text-primary transition-colors"
+								>
+									Guides
 								</Link>
 							</li>
 							<li>
-								<Link href="/examples" className="hover:text-primary transition-colors">
-									Examples
+								<Link
+									href="https://solana.com/developers/templates"
+									className="hover:text-primary transition-colors"
+								>
+									Templates
 								</Link>
 							</li>
 						</ul>

--- a/apps/docs/components/landing/hero.tsx
+++ b/apps/docs/components/landing/hero.tsx
@@ -1,19 +1,10 @@
 'use client';
 
 import { motion } from 'framer-motion';
-import { ArrowRight, Check, Copy } from 'lucide-react';
+import { ArrowRight } from 'lucide-react';
 import Link from 'next/link';
-import { useState } from 'react';
 
 export function Hero() {
-	const [copied, setCopied] = useState(false);
-
-	const onCopy = () => {
-		navigator.clipboard.writeText('npm install @solana/client');
-		setCopied(true);
-		setTimeout(() => setCopied(false), 2000);
-	};
-
 	return (
 		<section className="relative overflow-hidden pt-32 pb-20 lg:pt-40 lg:pb-28">
 			<div className="container relative z-10 mx-auto px-4 text-center">
@@ -91,19 +82,7 @@ export function Hero() {
 								<div className="w-3 h-3 rounded-full bg-[#27c93f]" />
 							</div>
 							<div className="text-xs text-white/40 font-sans select-none">examples/starter.ts</div>
-							<div className="flex items-center gap-2">
-								<button
-									type="button"
-									onClick={onCopy}
-									className="text-white/40 hover:text-white transition-colors"
-								>
-									{copied ? (
-										<Check className="w-4 h-4 text-green-400" />
-									) : (
-										<Copy className="w-4 h-4" />
-									)}
-								</button>
-							</div>
+							<div className="w-4 h-4" />
 						</div>
 
 						{/* Code Content */}


### PR DESCRIPTION
## Summary
- Set the `--fd-layout-width` CSS variable to 1400px to constrain the maximum width of the docs layout
- Removed copy button from landing page code snippet

## Changes
- Added `--fd-layout-width: 1400px` to the root CSS variables in `globals.css`
- Removed copy button and related state management from hero component

## Why
On wide screens, the layout was stretching too wide, causing the sidebar to be positioned far from the left edge. This change ensures the sidebar stays left-aligned and more accessible by constraining the overall layout width.

The copy button was removed from the landing page code snippet for a cleaner visual presentation.