### PR TITLE
fix(client): proper encoding and data for account notifications

### DIFF
--- a/packages/client/src/client/watchers.ts
+++ b/packages/client/src/client/watchers.ts
@@ -99,7 +99,7 @@ export function createWatchers({ logger: inputLogger, runtime, store }: WatcherD
 		abortController: AbortController,
 	): Promise<void> {
 		const commitment = config.commitment ?? store.getState().cluster.commitment;
-		const plan = runtime.rpcSubscriptions.accountNotifications(config.address, { commitment });
+		const plan = runtime.rpcSubscriptions.accountNotifications(config.address, { commitment, encoding: 'base64' });
 		const key = config.address.toString();
 		setSubscriptionStatus('account', key, { status: 'activating' });
 		abortController.signal.addEventListener('abort', () => onAbort('account', key));
@@ -113,7 +113,7 @@ export function createWatchers({ logger: inputLogger, runtime, store }: WatcherD
 				const slot = notification.context?.slot ?? null;
 				const entry: AccountCacheEntry = {
 					address: config.address,
-					data: notification.value?.data,
+					data: notification.value,
 					error: undefined,
 					executable,
 					fetching: false,


### PR DESCRIPTION
## Summary
`@solana/client` doesn't request base64 encoding for `handleAccountNotifications` even though it does for `fetchAccount`, so the account gets updated with data that is either base58 or an error about the account being too large for base58. The watcher also updates the account cache entry with `.data` which changes `account.data` from `Base64EncodedRpcAccount` to `Base64EncodedDataResponse`

I wasn't sure if this needed a changeset since it seems like a bug

## Testing
- [x] `pnpm lint`
- [x] `pnpm test`
- [x] `pnpm build`
- [x] Other (describe): I have been using a patched version of the library and `useAccount` is no longer returning a base58 error for large accounts, and updated data is correct without workarounds
