### PR TITLE
fix(web3-compat): correct types export path in declaration build

### DIFF
--- a/.changeset/grumpy-onions-rush.md
+++ b/.changeset/grumpy-onions-rush.md
@@ -1,0 +1,5 @@
+---
+"@solana/web3-compat": patch
+---
+
+Fix types export path so TypeScript can resolve the module

--- a/packages/web3-compat/tsconfig.declarations.json
+++ b/packages/web3-compat/tsconfig.declarations.json
@@ -3,7 +3,10 @@
 		"declaration": true,
 		"declarationMap": true,
 		"emitDeclarationOnly": true,
-		"outDir": "./dist/types"
+		"outDir": "./dist/types",
+		"paths": {
+			"@solana/client": ["../client/dist/types/index.d.ts"]
+		}
 	},
 	"extends": "./tsconfig.json",
 	"include": ["../build-scripts/build-time-constants.d.ts", "src/index.ts"]

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -500,6 +500,9 @@ importers:
       '@solana/react-hooks':
         specifier: workspace:*
         version: link:../../packages/react-hooks
+      '@solana/web3-compat':
+        specifier: workspace:*
+        version: link:../../packages/web3-compat
       react:
         specifier: catalog:react
         version: 19.2.3

--- a/tests/types-smoke/package.json
+++ b/tests/types-smoke/package.json
@@ -5,12 +5,13 @@
 	"type": "module",
 	"scripts": {
 		"test": "pnpm typecheck",
-		"pretypecheck": "pnpm --filter @solana/client build && pnpm --filter @solana/react-hooks build",
+		"pretypecheck": "pnpm --filter @solana/client build && pnpm --filter @solana/react-hooks build && pnpm --filter @solana/web3-compat build",
 		"typecheck": "tsc -p tsconfig.json"
 	},
 	"dependencies": {
 		"@solana/client": "workspace:*",
 		"@solana/react-hooks": "workspace:*",
+		"@solana/web3-compat": "workspace:*",
 		"react": "catalog:react"
 	},
 	"devDependencies": {

--- a/tests/types-smoke/src/index.ts
+++ b/tests/types-smoke/src/index.ts
@@ -12,4 +12,13 @@ type ProviderComponent = typeof import('@solana/react-hooks')['SolanaClientProvi
 type ProviderProps = Parameters<ProviderComponent>[0];
 const providerProps: ProviderProps = { client, children: null as unknown as ReactNode };
 
-export const _smokeTest: [ClientInstance, UseAccountResult, ProviderProps] = [client, hookResult, providerProps];
+type ConnectionClass = typeof import('@solana/web3-compat')['Connection'];
+type ConnectionInstance = InstanceType<ConnectionClass>;
+const connection = null as unknown as ConnectionInstance;
+
+export const _smokeTest: [ClientInstance, UseAccountResult, ProviderProps, ConnectionInstance] = [
+	client,
+	hookResult,
+	providerProps,
+	connection,
+];


### PR DESCRIPTION
## Summary
- `@solana/web3-compat` declares its types at `./dist/types/index.d.ts`, but the declaration build actually outputs to `./dist/types/web3-compat/src/index.d.ts`. TypeScript can't resolve the module without a manual `.d.ts` shim.
- The root cause is that `tsconfig.declarations.json` inherits a `paths` mapping from `tsconfig.json` that points `@solana/client` at raw `.ts` source files in `../client/src/`. This pulls the full client source tree into the program, widening the computed `rootDir` and nesting the output.
- Fix: override `paths` in the declarations tsconfig to resolve `@solana/client` from its built `.d.ts` files. This is the same pattern used by `react-hooks` (added in 6cdb52a).
- Also adds `@solana/web3-compat` to the type smoke tests so this gets caught by CI going forward.

## Testing
- [x] `pnpm lint`
- [x] `pnpm test`
- [x] `pnpm build`
- [x] `pnpm --filter @solana/test-types-smoke test`
- [x] Verified `dist/types/index.d.ts` exists after build (previously only `dist/types/web3-compat/src/index.d.ts` existed)